### PR TITLE
[UI, FEAT] 자산조회 화면에서의 UI 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.datastore.preferences)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
 }
@@ -73,7 +74,7 @@ dependencies {
     implementation(platform(libs.okhttp.bom))
     implementation(libs.retrofit)
     implementation(libs.retrofit2.kotlinx.serialization.converter)
-    implementation(libs.kotlinx.serialization.json)
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
     // Hilt
     implementation(libs.hilt.android)
     implementation(libs.hilt.core)

--- a/app/src/main/java/com/moneymate/moneymate/data/dto/account/request/TransactionHistoryRequest.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/account/request/TransactionHistoryRequest.kt
@@ -1,0 +1,14 @@
+package com.moneymate.moneymate.data.dto.account.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TransactionHistoryRequest(
+    @SerialName("accountUid")
+    val accountUid: String,
+    @SerialName("startDate")
+    val startDate: String,
+    @SerialName("endDate")
+    val endDate: String
+)

--- a/app/src/main/java/com/moneymate/moneymate/data/dto/account/response/AccountListResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/account/response/AccountListResponse.kt
@@ -1,0 +1,30 @@
+package com.moneymate.moneymate.data.dto.account.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AccountListResponse(
+    @SerialName("status")
+    val status: String,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: List<AccountInfo>
+)
+
+@Serializable
+data class AccountInfo(
+    @SerialName("accountUid")
+    val uid : Int,
+    @SerialName("accountBank")
+    val bankCode: String,
+    @SerialName("accountName")
+    val name: String,
+    @SerialName("accountType")
+    val type: String,
+    @SerialName("accountNumber")
+    val number: String,
+    @SerialName("accountBalance")
+    val balance: Int
+)

--- a/app/src/main/java/com/moneymate/moneymate/data/dto/account/response/AssetListResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/account/response/AssetListResponse.kt
@@ -1,0 +1,27 @@
+package com.moneymate.moneymate.data.dto.account.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AssetListResponse(
+    @SerialName("status")
+    val status: String,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: List<AssetInfo>
+)
+
+@Serializable
+data class AssetInfo(
+    @SerialName("assetUid")
+    val uid: Int,
+    @SerialName("assetName")
+    val name: String,
+    @SerialName("assetType")
+    val type: String,
+    @SerialName("assetPrice")
+    val price: Int
+)
+

--- a/app/src/main/java/com/moneymate/moneymate/data/dto/account/response/TransactionHistoryResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/account/response/TransactionHistoryResponse.kt
@@ -1,0 +1,30 @@
+package com.moneymate.moneymate.data.dto.account.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TransactionHistoryResponse(
+    @SerialName("status")
+    val status: String,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: List<Transaction>
+)
+
+@Serializable
+data class Transaction(
+    @SerialName("trDate")
+    val date: String,
+    @SerialName("trTime")
+    val time: String,
+    @SerialName("trOut")
+    val outAmount: Int,
+    @SerialName("trIn")
+    val inAmount: Int,
+    @SerialName("trAfterBalance")
+    val afterBalance: Int,
+    @SerialName("trDest")
+    val destination: String
+)

--- a/app/src/main/java/com/moneymate/moneymate/data/repository/AssetRepository.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/repository/AssetRepository.kt
@@ -1,9 +1,30 @@
 package com.moneymate.moneymate.data.repository
 
+import com.moneymate.moneymate.data.dto.account.request.TransactionHistoryRequest
 import com.moneymate.moneymate.data.service.AssetService
+import java.sql.Date
 
 class AssetRepository(
     private val assetService: AssetService
 ) {
+    // 전체 계좌 정보 조회
+    suspend fun getAccountList() = runCatching { assetService.getAccountList() }
 
+    // 계좌 내역 조회
+    suspend fun getTransactionHistory(
+        uid: String,
+        startDate: String,
+        endDate: String
+    ) = runCatching {
+        assetService.getTransactionHistory(
+            TransactionHistoryRequest(
+                accountUid = uid,
+                startDate = startDate,
+                endDate = endDate
+            )
+        )
+    }
+
+    // 전체 자산 조회
+    suspend fun getAssetList() = kotlin.runCatching { assetService.getAssetList() }
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/service/AssetService.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/service/AssetService.kt
@@ -1,4 +1,25 @@
 package com.moneymate.moneymate.data.service
 
+import com.moneymate.moneymate.data.dto.account.request.TransactionHistoryRequest
+import com.moneymate.moneymate.data.dto.account.response.AccountListResponse
+import com.moneymate.moneymate.data.dto.account.response.AssetListResponse
+import com.moneymate.moneymate.data.dto.account.response.TransactionHistoryResponse
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
 interface AssetService {
+    // 계좌 내역 조회
+    @POST("account/get-transaction")
+    suspend fun getTransactionHistory(
+        @Body request: TransactionHistoryRequest
+    ): TransactionHistoryResponse
+
+    // 전체 계좌 정보 조회
+    @GET("account/get-list")
+    suspend fun getAccountList(): AccountListResponse
+
+    // 전체 자산 조회
+    @GET("asset/get")
+    suspend fun getAssetList(): AssetListResponse
 }

--- a/app/src/main/java/com/moneymate/moneymate/di/NetworkModule.kt
+++ b/app/src/main/java/com/moneymate/moneymate/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.moneymate.moneymate.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.moneymate.moneymate.BuildConfig
+import com.moneymate.moneymate.util.auth.AuthInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -19,20 +20,26 @@ import javax.inject.Singleton
 object NetworkModule {
     @Provides
     @Singleton
-    fun providesOkHttpClient(): OkHttpClient {
-        val loggingInterceptor = HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY
-        }
-
-        return OkHttpClient.Builder()
-            .addInterceptor(loggingInterceptor)
-            .build()
-    }
+    fun providesOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor,
+        authInterceptor: AuthInterceptor,
+    ): OkHttpClient =
+        OkHttpClient.Builder().apply {
+            addInterceptor(loggingInterceptor)
+            addInterceptor(authInterceptor)
+        }.build()
 
     @Provides
     @Singleton
     fun providesConverterFactory(): Converter.Factory =
         Json.asConverterFactory("application/json".toMediaType())
+
+    @Provides
+    @Singleton
+    fun providesLoggingInterceptor(): HttpLoggingInterceptor =
+        HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/AssetViewModel.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/AssetViewModel.kt
@@ -1,13 +1,75 @@
 package com.moneymate.moneymate.ui.asset
 
+import android.util.Log
+import androidx.compose.ui.text.resolveDefaults
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.moneymate.moneymate.data.dto.account.response.AccountInfo
+import com.moneymate.moneymate.data.dto.account.response.AssetInfo
+import com.moneymate.moneymate.data.dto.account.response.Transaction
+import com.moneymate.moneymate.data.dto.account.response.TransactionHistoryResponse
 import com.moneymate.moneymate.data.repository.AssetRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class AssetViewModel @Inject constructor(
     private val assetRepository: AssetRepository
-): ViewModel() {
+) : ViewModel() {
+    // 홈 화면에서 조회할 전체 계좌 정보
+    private val _totalAccounts = MutableStateFlow<List<AccountInfo>?>(emptyList())
+    val totalAccounts = _totalAccounts.asStateFlow()
+    // 홈 화면에서 조회할 전체 자산 정보
+    private val _totalAssets= MutableStateFlow<List<AssetInfo>?>(emptyList())
+    val totalAssets = _totalAssets.asStateFlow()
+    // 계좌 거래 내역 정보
+    private val _transactionHistory = MutableStateFlow<List<Transaction>?>(emptyList())
 
+
+    // 전체 계좌 정보 조회
+    fun getTotalAccountList() {
+        viewModelScope.launch {
+            assetRepository.getAccountList()
+                .onSuccess { response ->
+                    _totalAccounts.value = response.data
+                }
+                .onFailure { response ->
+                    response.message?.let { Log.d("AssetViewModel", "게좌 조회 실패") }
+                }
+        }
+    }
+
+    // 계좌 내역 조회
+    fun getTransactionHistory(
+        uid: String,
+        startDate: String,
+        endDate: String
+    ){
+        viewModelScope.launch {
+            assetRepository.getTransactionHistory(uid = uid, startDate = startDate, endDate = endDate)
+                .onSuccess { response ->
+                    _transactionHistory.value = response.data
+                    Log.d("AssetViewModel", response.data.size.toString())
+                }
+                .onFailure { response ->
+                    response.message?.let { Log.d("AssetViewModel", "계좌 내역 조회 실패") }
+                }
+        }
+    }
+
+    // 전체 자산 조회
+    fun getAssetList() {
+        viewModelScope.launch {
+            assetRepository.getAssetList()
+                .onSuccess { response ->
+                    _totalAssets.value = response.data
+                }
+                .onFailure { response ->
+                    response.message?.let { Log.d("AssetViewModel", "자산 조회 실패") }
+                }
+        }
+    }
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/component/TransactionHistoryItem.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/component/TransactionHistoryItem.kt
@@ -1,0 +1,48 @@
+package com.moneymate.moneymate.ui.asset.component
+
+import android.widget.Space
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.moneymate.moneymate.data.dto.account.response.Transaction
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@Composable
+fun TransactionHistoryItem(
+    modifier: Modifier = Modifier,
+    transaction: Transaction
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(bottom = 20.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = transaction.time.substring(0,5),
+            style = MoneyMateTheme.typography.body_01_R_14,
+        )
+        Spacer(modifier = Modifier.size(20.dp))
+        Text(
+            text = transaction.destination,
+            style = MoneyMateTheme.typography.body_01_M_14,
+            modifier = Modifier.weight(1f)
+        )
+
+        val amount = if (transaction.outAmount > 0) "- %,d원".format(transaction.outAmount) else "+ %,d원".format(transaction.inAmount)
+
+        Text(
+            text = amount,
+            style = MoneyMateTheme.typography.head_03_B_16.copy(
+                color = MoneyMateTheme.colors.darkGray
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/AddAccountScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/AddAccountScreen.kt
@@ -2,6 +2,8 @@ package com.moneymate.moneymate.ui.asset.screen
 
 import android.graphics.Paint.Align
 import android.widget.Space
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -44,6 +46,8 @@ import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 @Composable
 fun AddAccountScreen(
     modifier: Modifier = Modifier,
+    accountType: String,
+    onNavigateBack: () -> Unit,
 //    viewModel: AssetViewModel = hiltViewModel()
 ) {
     var bankName by rememberSaveable { mutableStateOf("") }
@@ -53,20 +57,23 @@ fun AddAccountScreen(
         modifier = modifier.fillMaxSize(),
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MoneyMateTheme.colors.white)
         ) {
             TopAppBar(
                 modifier = Modifier,
                 title = {
                     Box(modifier = Modifier.fillMaxWidth()) {
                         Icon(
-                            modifier = Modifier,
+                            modifier = Modifier
+                                .clickable { onNavigateBack() },
                             painter = painterResource(id = R.drawable.ic_back),
                             contentDescription = "back icon"
                         )
                         Text(
                             modifier = Modifier.align(Alignment.Center),
-                            text = "입출금 계좌 등록",
+                            text = "$accountType 등록",
                             style = MoneyMateTheme.typography.head_02_B_20
                         )
                     }
@@ -77,11 +84,13 @@ fun AddAccountScreen(
             )
             Column(
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .fillMaxSize()
                     .padding(horizontal = 30.dp)
+                    .background(MoneyMateTheme.colors.white)
             ) {
+                Spacer(modifier = Modifier.size(12.dp))
                 Text(
-                    text = "사용자의 보유 입출금 계좌 등록 절차입니다.\n은행명과 계좌번호를 입력해주세요.",
+                    text = "사용자의 보유 $accountType 등록 절차입니다.\n은행명과 계좌번호를 입력해주세요.",
                     style = MoneyMateTheme.typography.head_03_R_16
                 )
                 // 은행명
@@ -143,5 +152,9 @@ fun AddAccountScreen(
 @Preview(showBackground = true)
 @Composable
 private fun AddAccountScreenPreview() {
-    AddAccountScreen()
+    AddAccountScreen(
+        modifier = Modifier,
+        accountType = "입출금",
+        onNavigateBack = {}
+    )
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/AddAccountScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/AddAccountScreen.kt
@@ -1,0 +1,147 @@
+package com.moneymate.moneymate.ui.asset.screen
+
+import android.graphics.Paint.Align
+import android.widget.Space
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.ui.asset.AssetViewModel
+import com.moneymate.moneymate.ui.common.BottomFullWidthButton
+import com.moneymate.moneymate.ui.common.MoneyMateTextField
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddAccountScreen(
+    modifier: Modifier = Modifier,
+//    viewModel: AssetViewModel = hiltViewModel()
+) {
+    var bankName by rememberSaveable { mutableStateOf("") }
+    var accountNumber by rememberSaveable { mutableStateOf("") }
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            TopAppBar(
+                modifier = Modifier,
+                title = {
+                    Box(modifier = Modifier.fillMaxWidth()) {
+                        Icon(
+                            modifier = Modifier,
+                            painter = painterResource(id = R.drawable.ic_back),
+                            contentDescription = "back icon"
+                        )
+                        Text(
+                            modifier = Modifier.align(Alignment.Center),
+                            text = "입출금 계좌 등록",
+                            style = MoneyMateTheme.typography.head_02_B_20
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MoneyMateTheme.colors.white
+                )
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 30.dp)
+            ) {
+                Text(
+                    text = "사용자의 보유 입출금 계좌 등록 절차입니다.\n은행명과 계좌번호를 입력해주세요.",
+                    style = MoneyMateTheme.typography.head_03_R_16
+                )
+                // 은행명
+                Spacer(modifier = Modifier.size(34.dp))
+                Text(
+                    text = "은행명",
+                    style = MoneyMateTheme.typography.head_03_SB_16
+                )
+                Spacer(modifier = Modifier.size(15.dp))
+                MoneyMateTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = bankName,
+                    onValueChange = {
+                        bankName = it
+                    },
+                    placeholder = {
+                        Text(
+                            text = "등록할 계좌의 은행명을 입력해주세요.",
+                            style = MoneyMateTheme.typography.body_01_M_14
+                        )
+                    }
+                )
+                // 계좌번호
+                Spacer(modifier = Modifier.size(34.dp))
+                Text(
+                    text = "계좌번호",
+                    style = MoneyMateTheme.typography.head_03_SB_16
+                )
+                Spacer(modifier = Modifier.size(15.dp))
+                MoneyMateTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = accountNumber,
+                    onValueChange = {
+                        accountNumber = it
+                    },
+                    placeholder = {
+                        Text(
+                            text = "등록할 계좌의 계좌번호를 입력해주세요.",
+                            style = MoneyMateTheme.typography.body_01_M_14
+                        )
+                    }
+                )
+            }
+        }
+        BottomFullWidthButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .padding(start = 20.dp, end = 20.dp, bottom = 20.dp),
+            containerColor = MoneyMateTheme.colors.deepBlue,
+            contentColor = MoneyMateTheme.colors.white,
+            text = "등록"
+        ) {
+            // TODO
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AddAccountScreenPreview() {
+    AddAccountScreen()
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/AddAssetScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/AddAssetScreen.kt
@@ -1,5 +1,7 @@
 package com.moneymate.moneymate.ui.asset.screen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -33,6 +35,8 @@ import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 @Composable
 fun AddAssetScreen(
     modifier: Modifier = Modifier,
+    assetType: String,
+    onNavigateBack: () -> Unit,
 //    viewModel: AssetViewModel = hiltViewModel()
 ) {
     var assetName by rememberSaveable { mutableStateOf("") }
@@ -42,20 +46,23 @@ fun AddAssetScreen(
         modifier = modifier.fillMaxSize(),
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MoneyMateTheme.colors.white)
         ) {
             TopAppBar(
                 modifier = Modifier,
                 title = {
                     Box(modifier = Modifier.fillMaxWidth()) {
                         Icon(
-                            modifier = Modifier,
+                            modifier = Modifier
+                                .clickable { onNavigateBack() },
                             painter = painterResource(id = R.drawable.ic_back),
                             contentDescription = "back icon"
                         )
                         Text(
                             modifier = Modifier.align(Alignment.Center),
-                            text = "자산 등록",
+                            text = "$assetType 정보 등록",
                             style = MoneyMateTheme.typography.head_02_B_20
                         )
                     }
@@ -66,11 +73,13 @@ fun AddAssetScreen(
             )
             Column(
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .fillMaxSize()
                     .padding(horizontal = 30.dp)
+                    .background(MoneyMateTheme.colors.white)
             ) {
+                Spacer(modifier = Modifier.size(12.dp))
                 Text(
-                    text = "사용자가 보유한 부동산 정보를 등록합니다.\n부동산의 가치와 이름을 입력해주세요.",
+                    text = "사용자가 보유한 $assetType 정보를 등록합니다.\n${assetType}의 가치와 이름을 입력해주세요.",
                     style = MoneyMateTheme.typography.head_03_R_16
                 )
                 // 은행명
@@ -88,7 +97,7 @@ fun AddAssetScreen(
                     },
                     placeholder = {
                         Text(
-                            text = "등록할 계좌의 은행명을 입력해주세요.",
+                            text = "등록할 ${assetType}의 이름을 입력해주세요.",
                             style = MoneyMateTheme.typography.body_01_M_14
                         )
                     }
@@ -108,7 +117,7 @@ fun AddAssetScreen(
                     },
                     placeholder = {
                         Text(
-                            text = "등록할 부동산의 자산 가치를 입력해주세요.",
+                            text = "등록할 ${assetType}의 가치를 입력해주세요.",
                             style = MoneyMateTheme.typography.body_01_M_14
                         )
                     }
@@ -132,5 +141,9 @@ fun AddAssetScreen(
 @Preview(showBackground = true)
 @Composable
 private fun AddAssetScreenPreview() {
-    AddAssetScreen()
+    AddAssetScreen(
+        modifier = Modifier,
+        assetType = "부동산",
+        onNavigateBack = {}
+    )
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/AddAssetScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/AddAssetScreen.kt
@@ -1,0 +1,136 @@
+package com.moneymate.moneymate.ui.asset.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.ui.asset.AssetViewModel
+import com.moneymate.moneymate.ui.common.BottomFullWidthButton
+import com.moneymate.moneymate.ui.common.MoneyMateTextField
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddAssetScreen(
+    modifier: Modifier = Modifier,
+//    viewModel: AssetViewModel = hiltViewModel()
+) {
+    var assetName by rememberSaveable { mutableStateOf("") }
+    var assetValue by rememberSaveable { mutableStateOf("") }
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            TopAppBar(
+                modifier = Modifier,
+                title = {
+                    Box(modifier = Modifier.fillMaxWidth()) {
+                        Icon(
+                            modifier = Modifier,
+                            painter = painterResource(id = R.drawable.ic_back),
+                            contentDescription = "back icon"
+                        )
+                        Text(
+                            modifier = Modifier.align(Alignment.Center),
+                            text = "자산 등록",
+                            style = MoneyMateTheme.typography.head_02_B_20
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MoneyMateTheme.colors.white
+                )
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 30.dp)
+            ) {
+                Text(
+                    text = "사용자가 보유한 부동산 정보를 등록합니다.\n부동산의 가치와 이름을 입력해주세요.",
+                    style = MoneyMateTheme.typography.head_03_R_16
+                )
+                // 은행명
+                Spacer(modifier = Modifier.size(34.dp))
+                Text(
+                    text = "이름",
+                    style = MoneyMateTheme.typography.head_03_SB_16
+                )
+                Spacer(modifier = Modifier.size(15.dp))
+                MoneyMateTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = assetName,
+                    onValueChange = {
+                        assetName = it
+                    },
+                    placeholder = {
+                        Text(
+                            text = "등록할 계좌의 은행명을 입력해주세요.",
+                            style = MoneyMateTheme.typography.body_01_M_14
+                        )
+                    }
+                )
+                // 계좌번호
+                Spacer(modifier = Modifier.size(34.dp))
+                Text(
+                    text = "자산 가치(원)",
+                    style = MoneyMateTheme.typography.head_03_SB_16
+                )
+                Spacer(modifier = Modifier.size(15.dp))
+                MoneyMateTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = assetValue,
+                    onValueChange = {
+                        assetValue = it
+                    },
+                    placeholder = {
+                        Text(
+                            text = "등록할 부동산의 자산 가치를 입력해주세요.",
+                            style = MoneyMateTheme.typography.body_01_M_14
+                        )
+                    }
+                )
+            }
+        }
+        BottomFullWidthButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .padding(start = 20.dp, end = 20.dp, bottom = 20.dp),
+            containerColor = MoneyMateTheme.colors.deepBlue,
+            contentColor = MoneyMateTheme.colors.white,
+            text = "등록"
+        ) {
+            // TODO
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AddAssetScreenPreview() {
+    AddAssetScreen()
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
@@ -26,7 +26,7 @@ fun HomeScreen(
     modifier: Modifier = Modifier,
     onAddAccountClick: (String) -> Unit,
     onAddAssetClick: (String) -> Unit,
-//    viewModel: AssetViewModel = hiltViewModel()
+    viewModel: AssetViewModel = hiltViewModel()
 ) {
     val scrollState = rememberScrollState()
 

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
@@ -24,6 +24,8 @@ import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
+    onAddAccountClick: (String) -> Unit,
+    onAddAssetClick: (String) -> Unit,
 //    viewModel: AssetViewModel = hiltViewModel()
 ) {
     val scrollState = rememberScrollState()
@@ -39,7 +41,9 @@ fun HomeScreen(
             name = "입출금 계좌",
             accountList = listOf(""),
             onItemClick = {},
-            onAddClick = {}
+            onAddClick = {
+                onAddAccountClick("입출금 계좌")
+            }
         )
         Spacer(modifier = Modifier.size(30.dp))
         // 적금 계좌
@@ -47,7 +51,9 @@ fun HomeScreen(
             name = "적금 계좌",
             accountList = listOf(),
             onItemClick = {},
-            onAddClick = {}
+            onAddClick = {
+                onAddAccountClick("적금 계좌")
+            }
         )
         Spacer(modifier = Modifier.size(30.dp))
         // 증권 계좌
@@ -55,24 +61,28 @@ fun HomeScreen(
             name = "증권 계좌",
             accountList = listOf(""),
             onItemClick = {},
-            onAddClick = {}
+            onAddClick = {
+                onAddAccountClick("증권 계좌")
+            }
         )
         Spacer(modifier = Modifier.size(30.dp))
         //부동산
         AssetContainer(
             name = "부동산",
-            assetList = listOf("")
-        ) {
-            // TODO
-        }
+            assetList = listOf(""),
+            onAddClick = {
+                onAddAssetClick("부동산")
+            }
+        )
         Spacer(modifier = Modifier.size(30.dp))
         // 투자
         AssetContainer(
-            name = "투자",
-            assetList = listOf()
-        ) {
-            // TODO
-        }
+            name = "투자 자산",
+            assetList = listOf(),
+            onAddClick = {
+                onAddAssetClick("투자 자산")
+            }
+        )
         Spacer(modifier = Modifier.size(30.dp))
     }
 }
@@ -80,5 +90,8 @@ fun HomeScreen(
 @Preview(showBackground = true)
 @Composable
 private fun HomeScreenPreview() {
-    HomeScreen()
+    HomeScreen(
+        onAddAccountClick = {},
+        onAddAssetClick = {}
+    )
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
@@ -37,7 +37,7 @@ fun HomeScreen(
         // 입출금 계좌
         AccountContainer(
             name = "입출금 계좌",
-            accountList = listOf(),
+            accountList = listOf(""),
             onItemClick = {},
             onAddClick = {}
         )

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
@@ -26,6 +26,7 @@ fun HomeScreen(
     modifier: Modifier = Modifier,
     onAddAccountClick: (String) -> Unit,
     onAddAssetClick: (String) -> Unit,
+    onAccountItemClick: () -> Unit,
     viewModel: AssetViewModel = hiltViewModel()
 ) {
     val scrollState = rememberScrollState()
@@ -40,7 +41,9 @@ fun HomeScreen(
         AccountContainer(
             name = "입출금 계좌",
             accountList = listOf(""),
-            onItemClick = {},
+            onItemClick = {
+                onAccountItemClick()
+            },
             onAddClick = {
                 onAddAccountClick("입출금 계좌")
             }
@@ -50,7 +53,9 @@ fun HomeScreen(
         AccountContainer(
             name = "적금 계좌",
             accountList = listOf(),
-            onItemClick = {},
+            onItemClick = {
+                onAccountItemClick()
+            },
             onAddClick = {
                 onAddAccountClick("적금 계좌")
             }
@@ -60,7 +65,9 @@ fun HomeScreen(
         AccountContainer(
             name = "증권 계좌",
             accountList = listOf(""),
-            onItemClick = {},
+            onItemClick = {
+                onAccountItemClick()
+            },
             onAddClick = {
                 onAddAccountClick("증권 계좌")
             }
@@ -92,6 +99,7 @@ fun HomeScreen(
 private fun HomeScreenPreview() {
     HomeScreen(
         onAddAccountClick = {},
-        onAddAssetClick = {}
+        onAddAssetClick = {},
+        onAccountItemClick = {}
     )
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/TransactionHistoryScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/TransactionHistoryScreen.kt
@@ -1,0 +1,148 @@
+package com.moneymate.moneymate.ui.asset.screen
+
+import android.widget.Space
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.data.dto.account.response.Transaction
+import com.moneymate.moneymate.ui.asset.component.TransactionHistoryItem
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+import com.moneymate.moneymate.util.formatDate
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TransactionHistoryScreen(
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+    val transactions: List<Transaction> = listOf(
+        Transaction(
+            date = "2025-05-01",
+            time = "12:34:56",
+            outAmount = 4000,
+            inAmount = 0,
+            afterBalance = 45000,
+            destination = "CU 건국대점"
+        ),
+        Transaction(
+            date = "2025-05-01",
+            time = "13:34:56",
+            outAmount = 4000,
+            inAmount = 0,
+            afterBalance = 45000,
+            destination = "학생식당"
+        ),
+        Transaction(
+            date = "2025-05-01",
+            time = "14:34:56",
+            outAmount = 0,
+            inAmount = 1000000,
+            afterBalance = 45000,
+            destination = "카카오페이"
+        ),
+
+        Transaction(
+            date = "2025-05-03",
+            time = "13:34:56",
+            outAmount = 4000,
+            inAmount = 0,
+            afterBalance = 45000,
+            destination = "CU 건국대점"
+        ),
+    )
+    // Pass your data here
+    val grouped = transactions.groupBy { it.date }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TopAppBar(
+            modifier = Modifier,
+            title = {
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    Icon(
+                        modifier = Modifier,
+                        painter = painterResource(id = R.drawable.ic_back),
+                        contentDescription = "back icon"
+                    )
+                    Text(
+                        modifier = Modifier.align(Alignment.Center),
+                        text = "거래 내역 조회",
+                        style = MoneyMateTheme.typography.head_02_B_20
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MoneyMateTheme.colors.white
+            )
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 30.dp)
+                .verticalScroll(scrollState)
+        ) {
+            Spacer(modifier = Modifier.size(15.dp))
+            Text(
+                text = "KB국민은행 57370104098146",
+                style = MoneyMateTheme.typography.head_03_R_16.copy(
+                    color = MoneyMateTheme.colors.darkGray
+                )
+            )
+            Text(
+                text = "888,888원",
+                style = MoneyMateTheme.typography.head_01_B_24
+            )
+            Spacer(modifier = Modifier.size(20.dp))
+            HorizontalDivider(
+                modifier = Modifier.fillMaxWidth(),
+                thickness = 1.dp,
+                color = MoneyMateTheme.colors.deepBlue
+            )
+            Spacer(modifier = Modifier.size(20.dp))
+            // 날짜별로 거래내역 그룹화
+            grouped.forEach { (date, transactionsOnDate) ->
+                Text(
+                    text = formatDate(date),
+                    style = MoneyMateTheme.typography.head_03_SB_16.copy(
+                        color = MoneyMateTheme.colors.deepBlue
+                    ),
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+                transactionsOnDate
+                    .sortedByDescending { it.time }
+                    .forEach { transactions ->
+                        TransactionHistoryItem(
+                            modifier = Modifier,
+                            transaction = transactions
+                        )
+                    }
+            }
+        }
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+private fun TransactionHistoryScreenPreview() {
+    TransactionHistoryScreen()
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/TransactionHistoryScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/TransactionHistoryScreen.kt
@@ -1,6 +1,8 @@
 package com.moneymate.moneymate.ui.asset.screen
 
 import android.widget.Space
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -33,6 +35,7 @@ import com.moneymate.moneymate.util.formatDate
 @Composable
 fun TransactionHistoryScreen(
     modifier: Modifier = Modifier,
+    onNavigateBack: () -> Unit
 ) {
     val scrollState = rememberScrollState()
     val transactions: List<Transaction> = listOf(
@@ -73,13 +76,19 @@ fun TransactionHistoryScreen(
     // Pass your data here
     val grouped = transactions.groupBy { it.date }
 
-    Column(modifier = modifier.fillMaxSize()) {
+    Column(modifier = modifier
+        .fillMaxSize()
+        .background(MoneyMateTheme.colors.white)
+    ) {
         TopAppBar(
             modifier = Modifier,
             title = {
                 Box(modifier = Modifier.fillMaxWidth()) {
                     Icon(
-                        modifier = Modifier,
+                        modifier = Modifier
+                            .clickable {
+                                onNavigateBack()
+                            },
                         painter = painterResource(id = R.drawable.ic_back),
                         contentDescription = "back icon"
                     )
@@ -144,5 +153,8 @@ fun TransactionHistoryScreen(
 @Preview(showBackground = true)
 @Composable
 private fun TransactionHistoryScreenPreview() {
-    TransactionHistoryScreen()
+    TransactionHistoryScreen(
+        modifier = Modifier,
+        onNavigateBack = {}
+    )
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/common/BottomFullWidthButton.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/common/BottomFullWidthButton.kt
@@ -1,0 +1,61 @@
+package com.moneymate.moneymate.ui.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@Composable
+fun BottomFullWidthButton(
+    modifier: Modifier = Modifier,
+    containerColor: Color,
+    contentColor: Color,
+    text: String,
+    onClick: () -> Unit
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .shadow(elevation = 4.dp, shape = RoundedCornerShape(8.dp)),
+        shape = RoundedCornerShape(8.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = containerColor,
+            contentColor = contentColor
+        ),
+    ) {
+        Text(
+            text = text,
+            style = MoneyMateTheme.typography.head_03_B_16,
+            color = contentColor
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BottomFullWidthButtonPreview() {
+    Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.Center) {
+        BottomFullWidthButton(
+            containerColor = MoneyMateTheme.colors.deepBlue,
+            contentColor = MoneyMateTheme.colors.white,
+            text = "버튼"
+        ) {
+            //onClick 작성
+        }
+    }
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/common/MoneyMateTextField.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/common/MoneyMateTextField.kt
@@ -1,0 +1,66 @@
+package com.moneymate.moneymate.ui.common
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@Composable
+fun MoneyMateTextField(
+    modifier: Modifier = Modifier,
+    text: String,
+    onValueChange: (String) -> Unit,
+    placeholder: @Composable (() -> Unit)? = null,
+) {
+    TextField(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp)),
+        value = text,
+        onValueChange = onValueChange,
+        placeholder = {
+            placeholder?.invoke()
+        },
+        colors = TextFieldDefaults.colors(
+            focusedContainerColor = MoneyMateTheme.colors.backgroundWhite,
+            focusedTextColor = MoneyMateTheme.colors.darkGray,
+            unfocusedContainerColor = MoneyMateTheme.colors.backgroundWhite,
+            unfocusedTextColor = MoneyMateTheme.colors.darkGray,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            focusedPlaceholderColor = MoneyMateTheme.colors.lightGray,
+            unfocusedPlaceholderColor = MoneyMateTheme.colors.lightGray,
+        ),
+    )
+}
+
+@Preview
+@Composable
+private fun MoneyMateTextFieldPreview(){
+    var text by rememberSaveable { mutableStateOf("") }
+
+    MoneyMateTextField(
+        modifier = Modifier.fillMaxWidth(), // 크기 지정 필요한 경우 Modifier를 통해 지정(예: fillMaxWidth(), size() 등)
+        text = text,
+        onValueChange = {
+            text = it
+        },
+        placeholder = {
+            Text(
+                text = "placeholder",
+                style = MoneyMateTheme.typography.body_01_M_14
+            )
+        }
+    )
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
@@ -11,6 +11,7 @@ import com.moneymate.moneymate.ui.manage.screen.ManageScreen
 import com.moneymate.moneymate.ui.mypage.screen.MyPageScreen
 import com.moneymate.moneymate.ui.asset.screen.AddAccountScreen
 import com.moneymate.moneymate.ui.asset.screen.AddAssetScreen
+import com.moneymate.moneymate.ui.asset.screen.TransactionHistoryScreen
 
 @Composable
 fun MoneyMateNavGraph(
@@ -33,6 +34,9 @@ fun MoneyMateNavGraph(
                 },
                 onAddAssetClick = { assetType ->
                     navController.navigate("${Route.AddAsset.route}/$assetType")
+                },
+                onAccountItemClick = {
+                    navController.navigate(Route.TransactionHistory.route)
                 }
             )
         }
@@ -57,6 +61,17 @@ fun MoneyMateNavGraph(
             AddAssetScreen(
                 modifier = modifier,
                 assetType = assetType,
+                onNavigateBack = {
+                    navController.navigateUp()
+                }
+            )
+        }
+        // 거래내역 조회 화면
+        composable(
+            route = Route.TransactionHistory.route
+        ){
+            TransactionHistoryScreen(
+                modifier = modifier,
                 onNavigateBack = {
                     navController.navigateUp()
                 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
@@ -9,6 +9,8 @@ import com.moneymate.moneymate.ui.asset.screen.HomeScreen
 import com.moneymate.moneymate.ui.finance.screen.FinanceScreen
 import com.moneymate.moneymate.ui.manage.screen.ManageScreen
 import com.moneymate.moneymate.ui.mypage.screen.MyPageScreen
+import com.moneymate.moneymate.ui.asset.screen.AddAccountScreen
+import com.moneymate.moneymate.ui.asset.screen.AddAssetScreen
 
 @Composable
 fun MoneyMateNavGraph(
@@ -19,31 +21,63 @@ fun MoneyMateNavGraph(
         navController = navController,
         startDestination = Route.Home.route
     ){
-        // 인증/인가
+        /* 인증/인가 */
 
 
-        // 자산 조회(홈)
+        /*자산 조회(홈)*/
         composable(route = Route.Home.route) {
             HomeScreen(
-                modifier = modifier
+                modifier = modifier,
+                onAddAccountClick = { accountType ->
+                    navController.navigate("${Route.AddAccount.route}/$accountType")
+                },
+                onAddAssetClick = { assetType ->
+                    navController.navigate("${Route.AddAsset.route}/$assetType")
+                }
+            )
+        }
+        // 계좌 추가 화면
+        composable(
+            route = "${Route.AddAccount.route}/{accountType}",
+        ) { backStackEntry ->
+            val accountType = backStackEntry.arguments?.getString("accountType") ?: ""
+            AddAccountScreen(
+                modifier = modifier,
+                accountType = accountType,
+                onNavigateBack = {
+                    navController.navigateUp()
+                }
+            )
+        }
+        // 자산 추가 화면
+        composable(
+            route = "${Route.AddAsset.route}/{assetType}",
+        ) { backStackEntry ->
+            val assetType = backStackEntry.arguments?.getString("assetType") ?: ""
+            AddAssetScreen(
+                modifier = modifier,
+                assetType = assetType,
+                onNavigateBack = {
+                    navController.navigateUp()
+                }
             )
         }
 
-        // 금융 정보
+        /* 금융 정보 */
         composable(route = Route.Finance.route) {
             FinanceScreen(
                 modifier = modifier
             )
         }
 
-        // 자산 관리
+        /* 자산 관리 */
         composable(route = Route.Manage.route) {
             ManageScreen(
                 modifier = modifier
             )
         }
 
-        // 마이페이지
+        /* 마이페이지 */
         composable(route = Route.MyPage.route) {
             MyPageScreen(
                 modifier = modifier

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
@@ -3,6 +3,9 @@ package com.moneymate.moneymate.ui.navigation
 sealed class Route(val route: String){
     // 자산 조회(홈)
     object Home: Route(route = "home")
+    object AddAccount: Route(route = "home/addAccount")
+    object AddAsset: Route(route = "home/addAsset")
+    object TransactionHistory: Route(route = "home/transactionHistory")
 
     // 금융 정보
     object Finance: Route(route = "finance")

--- a/app/src/main/java/com/moneymate/moneymate/ui/theme/Type.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/theme/Type.kt
@@ -29,6 +29,7 @@ data class MoneyMateTypography(
     val body_01_R_14: TextStyle,
     val body_02_SB_12: TextStyle,
     val body_02_R_12: TextStyle,
+    val body_03_M_20: TextStyle,
 
     // Caption
     val caption_01_R_10: TextStyle
@@ -92,6 +93,11 @@ val defaultMoneyMateTypography = MoneyMateTypography(
         fontFamily = moneyMateFontRegular,
         fontSize = 12.sp,
         lineHeight = 12.sp
+    ),
+    body_03_M_20 = TextStyle(
+        fontFamily = moneyMateFontMedium,
+        fontSize = 20.sp,
+        lineHeight = 20.sp
     ),
 
     // Caption

--- a/app/src/main/java/com/moneymate/moneymate/util/DateUtil.kt
+++ b/app/src/main/java/com/moneymate/moneymate/util/DateUtil.kt
@@ -1,0 +1,6 @@
+package com.moneymate.moneymate.util
+
+// "2025-05-11" -> "5월 11일")
+fun formatDate(date: String): String {
+    return "${date.substring(5, 7).toInt()}월 ${date.substring(8, 10).toInt()}일"
+}

--- a/app/src/main/java/com/moneymate/moneymate/util/auth/AuthInterceptor.kt
+++ b/app/src/main/java/com/moneymate/moneymate/util/auth/AuthInterceptor.kt
@@ -1,0 +1,26 @@
+package com.moneymate.moneymate.util.auth
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class AuthInterceptor @Inject constructor(
+    private val tokenManager: TokenManager
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+        val accessToken =
+            runBlocking { tokenManager.getAccessToken().flowOn(Dispatchers.IO).first() }
+
+        accessToken?.let {
+            // header에 토큰을 추가
+            request
+                .addHeader("Authorization", "Bearer $it")
+        }
+        return chain.proceed(request.build())
+    }
+}

--- a/app/src/main/java/com/moneymate/moneymate/util/auth/TokenManager.kt
+++ b/app/src/main/java/com/moneymate/moneymate/util/auth/TokenManager.kt
@@ -1,0 +1,52 @@
+package com.moneymate.moneymate.util.auth
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.dataStore by preferencesDataStore(name = "user_prefs")
+
+@Singleton
+class TokenManager @Inject constructor(@ApplicationContext private val context: Context) {
+    companion object {
+        private val ACCESS_TOKEN = stringPreferencesKey("access_token")
+        private val REFRESH_TOKEN = stringPreferencesKey("refresh_token")
+    }
+
+    fun getAccessToken(): Flow<String?> {
+        return context.dataStore.data.map { preferences ->
+            preferences[ACCESS_TOKEN]
+        }
+    }
+
+    fun getRefreshToken(): Flow<String?> {
+        return context.dataStore.data.map { preferences ->
+            preferences[REFRESH_TOKEN]
+        }
+    }
+
+    suspend fun saveAccessToken(accessToken: String) {
+        context.dataStore.edit { preferences ->
+            preferences[ACCESS_TOKEN] = accessToken
+        }
+    }
+
+    suspend fun saveRefreshToken(refreshToken: String) {
+        context.dataStore.edit { preferences ->
+            preferences[REFRESH_TOKEN] = refreshToken
+        }
+    }
+
+    suspend fun clearToken() {
+        context.dataStore.edit { preferences ->
+            preferences.remove(ACCESS_TOKEN)
+            preferences.remove(REFRESH_TOKEN)
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_back.xml
+++ b/app/src/main/res/drawable/ic_back.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="25dp"
+    android:height="25dp"
+    android:viewportWidth="25"
+    android:viewportHeight="25">
+  <path
+      android:pathData="M16.016,5.469L8.984,12.5L16.016,19.531"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#333333"
+      android:strokeLineCap="round"/>
+</vector>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ hilt = "2.50"
 hiltNavigationCompose = "1.2.0"
 hiltManager = "1.0.0"
 ksp = "2.0.21-1.0.28"
+datastorePreferences = "1.2.0-alpha02"
 
 
 [libraries]
@@ -49,6 +50,7 @@ hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 hilt-manager = {group = "androidx.hilt" , name = "hilt-compiler", version.ref = "hiltManager"}
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,5 +54,6 @@ hilt-manager = {group = "androidx.hilt" , name = "hilt-compiler", version.ref = 
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = {id = "com.google.devtools.ksp", version.ref = "ksp"}


### PR DESCRIPTION
## 🚀 이슈번호
- resolves #3 
- #5 

## ✏️ 변경사항
- 공통으로 사용할 수 있는 하단부의 버튼인 BottomFullWidthButton 컴포넌트 작성
- 공통으로 사용할 수 있는 TextField인 MoneyMateTextField 작성
- 각 계좌/자산에 대해서 추가 버튼을 누르면 해당하는 String을 넘겨받아서 보여주는 화면 작성 
- API 연결시에 사용할 interceptor, TokenManager 작성
- 필요한 화면으로의 Navigation 연결
- 값과 날짜를 formatting 해주는 함수를 util/에 작성
- 자산 관련 API에 사용할 Service, Repository, ViewModel 코드 작성

## 📷 스크린샷
https://github.com/user-attachments/assets/ed2a0035-1287-4198-83be-abbd1082f2d2



## ✍️ 사용법
BottomFullWidthButton
- Modifier를 통해 크기를 설정하고 필요한 파라미터에 값을 할당하여 사용

MoneyMateTextField
- Modifier를 통해 크기를 설정하여 사용, 공통으로 사용되는 회색 textfield

## 🎸 기타
- API를 통해 실제 보유 계좌/자산 불러오는 것은 더미데이터 생성되면 PR에 구현해놓겠습니다.