### PR TITLE
[UI, FEAT] 경제 뉴스 화면 구성 및 api 연결

### DIFF
--- a/app/src/main/java/com/moneymate/moneymate/data/dto/finance/NewsInfo.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/finance/NewsInfo.kt
@@ -1,0 +1,22 @@
+package com.moneymate.moneymate.data.dto.finance
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NewsInfo(
+    @SerialName("title")
+    val title: String,
+    @SerialName("link")
+    val link: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("publisher")
+    val publisher: String,
+    @SerialName("category")
+    val category: String,
+    @SerialName("pubDate")
+    val pubDate: String,
+    @SerialName("author")
+    val author: String,
+)

--- a/app/src/main/java/com/moneymate/moneymate/data/dto/finance/response/NewsDetailResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/finance/response/NewsDetailResponse.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class NewsListResponse(
+data class NewsDetailResponse(
     @SerialName("status")
     val status: String,
     @SerialName("message")

--- a/app/src/main/java/com/moneymate/moneymate/data/dto/finance/response/NewsListResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/finance/response/NewsListResponse.kt
@@ -1,0 +1,32 @@
+package com.moneymate.moneymate.data.dto.finance.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NewsListResponse(
+    @SerialName("status")
+    val status: String,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: List<NewsInfo>,
+)
+
+@Serializable
+data class NewsInfo(
+    @SerialName("title")
+    val title: String,
+    @SerialName("link")
+    val link: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("publisher")
+    val publisher: String,
+    @SerialName("category")
+    val category: String,
+    @SerialName("pubDate")
+    val pubDate: String,
+    @SerialName("author")
+    val author: String,
+)

--- a/app/src/main/java/com/moneymate/moneymate/data/repository/FinanceRepository.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/repository/FinanceRepository.kt
@@ -1,9 +1,12 @@
 package com.moneymate.moneymate.data.repository
 
+import com.moneymate.moneymate.data.dto.finance.response.NewsInfo
 import com.moneymate.moneymate.data.service.FinanceService
 
 class FinanceRepository(
     private val financeService: FinanceService
 ) {
-
+    suspend fun getNewsList() : List<NewsInfo> {
+        return financeService.getNewsList().data
+    }
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/repository/FinanceRepository.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/repository/FinanceRepository.kt
@@ -1,6 +1,6 @@
 package com.moneymate.moneymate.data.repository
 
-import com.moneymate.moneymate.data.dto.finance.response.NewsInfo
+import com.moneymate.moneymate.data.dto.finance.NewsInfo
 import com.moneymate.moneymate.data.service.FinanceService
 
 class FinanceRepository(
@@ -8,5 +8,9 @@ class FinanceRepository(
 ) {
     suspend fun getNewsList() : List<NewsInfo> {
         return financeService.getNewsList().data
+    }
+
+    suspend fun getCategoryNews(publisher : String, category:String) : List<NewsInfo> {
+        return financeService.getNewsDetail(publisher,category).data
     }
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/service/FinanceService.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/service/FinanceService.kt
@@ -1,4 +1,9 @@
 package com.moneymate.moneymate.data.service
 
+import com.moneymate.moneymate.data.dto.finance.response.NewsListResponse
+import retrofit2.http.GET
+
 interface FinanceService {
+    @GET("news/all")
+    suspend fun getNewsList(): NewsListResponse
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/service/FinanceService.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/service/FinanceService.kt
@@ -1,9 +1,17 @@
 package com.moneymate.moneymate.data.service
 
+import com.moneymate.moneymate.data.dto.finance.response.NewsDetailResponse
 import com.moneymate.moneymate.data.dto.finance.response.NewsListResponse
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface FinanceService {
     @GET("news/all")
     suspend fun getNewsList(): NewsListResponse
+
+    @GET("news/detail")
+    suspend fun getNewsDetail(
+        @Query("publisher") publisher : String,
+        @Query("category") category: String
+    ) : NewsDetailResponse
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/common/MoneyMateMenuButton.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/common/MoneyMateMenuButton.kt
@@ -1,0 +1,68 @@
+package com.moneymate.moneymate.ui.common
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@Composable
+fun MoneyMateMenuButton(
+    text: String,
+    height: Int,
+    onClick : () ->Unit
+) {
+    Card(
+        modifier = Modifier
+            .height(height.dp)
+            .width(360.dp)
+            .clickable {onClick()},
+        shape = RoundedCornerShape(20.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MoneyMateTheme.colors.white
+        )
+
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 29.dp, end = 21.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = text,
+                color = MoneyMateTheme.colors.darkGray,
+                style = TextStyle(
+                    fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
+                    fontSize = 20.sp
+                )
+            )
+            Icon(
+                painter = painterResource(id = R.drawable.ic_mypage_arrow),
+                contentDescription = "화살표 아이콘",
+                tint = Color.Gray
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/FinanceViewModel.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/FinanceViewModel.kt
@@ -1,13 +1,41 @@
 package com.moneymate.moneymate.ui.finance
 
+import android.util.Log
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.moneymate.moneymate.data.dto.finance.response.NewsInfo
+import com.moneymate.moneymate.data.repository.FinanceRepository
 import com.moneymate.moneymate.data.service.FinanceService
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class FinanceViewModel @Inject constructor(
-    private val financeService: FinanceService
+    private val financeRepository: FinanceRepository
 ): ViewModel() {
+
+    private val _newsList = mutableStateOf<List<NewsInfo>>(emptyList())
+    val newsList: State<List<NewsInfo>> = _newsList
+
+    init {
+        getNewsList()
+    }
+
+    fun getNewsList(){
+        viewModelScope.launch {
+            runCatching { financeRepository.getNewsList() }
+                .onSuccess {
+                    _newsList.value = it
+                    Log.d("AssetViewModel", "조회 성공")
+                }
+                .onFailure { response ->
+                    response.message?.let { Log.d("AssetViewModel", response.message.toString()) }
+                }
+        }
+    }
+
 
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/FinanceViewModel.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/FinanceViewModel.kt
@@ -5,9 +5,8 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.moneymate.moneymate.data.dto.finance.response.NewsInfo
+import com.moneymate.moneymate.data.dto.finance.NewsInfo
 import com.moneymate.moneymate.data.repository.FinanceRepository
-import com.moneymate.moneymate.data.service.FinanceService
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -20,6 +19,9 @@ class FinanceViewModel @Inject constructor(
     private val _newsList = mutableStateOf<List<NewsInfo>>(emptyList())
     val newsList: State<List<NewsInfo>> = _newsList
 
+    private val _categoryNewsList = mutableStateOf<List<NewsInfo>>(emptyList())
+    val categoryNewsList: State<List<NewsInfo>> = _categoryNewsList
+
     init {
         getNewsList()
     }
@@ -29,10 +31,23 @@ class FinanceViewModel @Inject constructor(
             runCatching { financeRepository.getNewsList() }
                 .onSuccess {
                     _newsList.value = it
-                    Log.d("AssetViewModel", "조회 성공")
+                    Log.d("FinanceViewModel", "조회 성공")
                 }
                 .onFailure { response ->
-                    response.message?.let { Log.d("AssetViewModel", response.message.toString()) }
+                    response.message?.let { Log.d("FinanceViewModel", response.message.toString()) }
+                }
+        }
+    }
+
+    fun getCategoryNews(publisher : String, category : String) {
+        viewModelScope.launch {
+            runCatching { financeRepository.getCategoryNews(publisher, category) }
+                .onSuccess {
+                    _categoryNewsList.value = it
+                    Log.d("FinanceViewModel", "조회 성공")
+                }
+                .onFailure { response ->
+                    response.message?.let { Log.d("FinanceViewModel", response.message.toString()) }
                 }
         }
     }

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/ArticleData.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/ArticleData.kt
@@ -1,0 +1,6 @@
+package com.moneymate.moneymate.ui.finance.component
+
+data class ArticleData(
+    val title: String,
+    val url: String,
+)

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsCategoryButton.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsCategoryButton.kt
@@ -27,6 +27,14 @@ fun NewsCategoryButton(
     isSelected: Boolean,
     onClick: () -> Unit,
 ) {
+    var categoryToKorean = "economy"
+    if (category=="economy") categoryToKorean = "경제"
+    else if (category=="finance") categoryToKorean = "금융"
+    else if (category=="stock") categoryToKorean = "증권"
+    else if (category=="realestate") categoryToKorean = "부동산"
+    else if (category=="business") categoryToKorean = "기업/경영"
+
+
     Row(
         modifier = Modifier
             .height(42.dp)
@@ -42,7 +50,7 @@ fun NewsCategoryButton(
 
     ) {
         Text(
-            text = category,
+            text = categoryToKorean,
             style = TextStyle(
                 color = if (isSelected) MoneyMateTheme.colors.white else MoneyMateTheme.colors.deepBlue,
                 fontSize = 18.sp,
@@ -56,7 +64,7 @@ fun NewsCategoryButton(
 @Composable
 fun NewsCategoryButtonPreview(
     modifier: Modifier = Modifier,
-    category: String = "경제",
+    category: String = "부동산",
     isSelected: Boolean = false,
     onClick: () -> Unit = {},
 ) {

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsCategoryButton.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsCategoryButton.kt
@@ -1,0 +1,86 @@
+package com.moneymate.moneymate.ui.finance.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@Composable
+fun NewsCategoryButton(
+    category: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .height(42.dp)
+            .width(91.dp)
+            .border(2.dp, MoneyMateTheme.colors.deepBlue, RoundedCornerShape(25.dp))
+            .background(
+                color = if (isSelected) MoneyMateTheme.colors.deepBlue else MoneyMateTheme.colors.white,
+                shape = RoundedCornerShape(25.dp)
+            )
+            .clickable { onClick() },
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+
+    ) {
+        Text(
+            text = category,
+            style = TextStyle(
+                color = if (isSelected) MoneyMateTheme.colors.white else MoneyMateTheme.colors.deepBlue,
+                fontSize = 18.sp,
+                fontFamily = FontFamily(Font(R.font.pretendard_semibold))
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NewsCategoryButtonPreview(
+    modifier: Modifier = Modifier,
+    category: String = "경제",
+    isSelected: Boolean = false,
+    onClick: () -> Unit = {},
+) {
+    Row(
+        modifier = Modifier
+            .height(42.dp)
+            .width(91.dp)
+            .border(2.dp, MoneyMateTheme.colors.deepBlue, RoundedCornerShape(25.dp))
+            .background(
+                color = if (isSelected) MoneyMateTheme.colors.deepBlue else MoneyMateTheme.colors.white,
+                shape = RoundedCornerShape(25.dp)
+            )
+            .clickable { onClick() },
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+
+    ) {
+        Text(
+            text = category,
+            style = TextStyle(
+                color = if (isSelected) MoneyMateTheme.colors.white else MoneyMateTheme.colors.deepBlue,
+                fontSize = 18.sp,
+                fontFamily = FontFamily(Font(R.font.pretendard_semibold))
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainer.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainer.kt
@@ -1,0 +1,90 @@
+package com.moneymate.moneymate.ui.finance.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@Composable
+fun NewsContainer(
+    publisher: String,
+    articles: List<String>, //TODO 수정할것
+    onAddClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color = MoneyMateTheme.colors.white)
+            .height(224.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(47.dp)
+                .padding(horizontal = 28.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = publisher,
+                style = TextStyle(
+                    fontSize = 16.sp,
+                    fontFamily = FontFamily(Font(R.font.pretendard_regular))
+                )
+            )
+            Row(
+                modifier = Modifier
+                    .clickable { onAddClick() },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "더보기",
+                    style = TextStyle(
+                        fontSize = 16.sp,
+                        fontFamily = FontFamily(Font(R.font.pretendard_regular))
+                    )
+                )
+                Icon(
+                    painter = painterResource(R.drawable.ic_mypage_arrow),
+                    contentDescription = "더보기",
+                    modifier = Modifier
+                        .size(16.dp)
+                )
+            }
+
+        }
+        Column(
+            modifier = Modifier
+                .padding(bottom = 12.dp, start = 28.dp, end = 28.dp)
+        ) {
+            articles.take(4).forEachIndexed { index, article ->
+                val isLast = index == articles.take(4).lastIndex
+                NewsItem(
+                    title = article,
+                    url = "",
+                    isLastArticle = isLast,
+                    onClick = { }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainer.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainer.kt
@@ -44,7 +44,7 @@ fun NewsContainer(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = news.publisher,
+                text = news.publisher.publisherName,
                 style = TextStyle(
                     fontSize = 16.sp,
                     fontFamily = FontFamily(Font(R.font.pretendard_regular))
@@ -52,7 +52,7 @@ fun NewsContainer(
             )
             Row(
                 modifier = Modifier
-                    .clickable { onAddClick(news.publisher) }, //언론사 홈으로
+                    .clickable { onAddClick(news.publisher.publisherName) }, //언론사 홈으로
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainer.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainer.kt
@@ -33,7 +33,6 @@ fun NewsContainer(
         modifier = Modifier
             .fillMaxWidth()
             .background(color = MoneyMateTheme.colors.white)
-            .height(224.dp)
     ) {
         Row(
             modifier = Modifier
@@ -52,7 +51,7 @@ fun NewsContainer(
             )
             Row(
                 modifier = Modifier
-                    .clickable { onAddClick(news.publisher.publisherName) }, //언론사 홈으로
+                    .clickable { onAddClick(news.publisher.enum) }, //언론사 홈으로
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainer.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainer.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
@@ -26,9 +25,9 @@ import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 
 @Composable
 fun NewsContainer(
-    publisher: String,
-    articles: List<String>, //TODO 수정할것
-    onAddClick: () -> Unit,
+    news: NewsContainerData,
+    onAddClick: (String) -> Unit,
+    onArticleClick: (String) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -45,7 +44,7 @@ fun NewsContainer(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = publisher,
+                text = news.publisher,
                 style = TextStyle(
                     fontSize = 16.sp,
                     fontFamily = FontFamily(Font(R.font.pretendard_regular))
@@ -53,7 +52,7 @@ fun NewsContainer(
             )
             Row(
                 modifier = Modifier
-                    .clickable { onAddClick() },
+                    .clickable { onAddClick(news.publisher) }, //언론사 홈으로
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
@@ -76,13 +75,14 @@ fun NewsContainer(
             modifier = Modifier
                 .padding(bottom = 12.dp, start = 28.dp, end = 28.dp)
         ) {
-            articles.take(4).forEachIndexed { index, article ->
-                val isLast = index == articles.take(4).lastIndex
+
+            news.articles.take(4).forEachIndexed { index, article ->
+                val isLast = index == news.articles.take(4).lastIndex
                 NewsItem(
-                    title = article,
-                    url = "",
+                    title = article.title,
+                    url = article.url,
                     isLastArticle = isLast,
-                    onClick = { }
+                    onArticleClick = { onArticleClick(article.url) } //기사 링크로 이동
                 )
             }
         }

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainerData.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainerData.kt
@@ -1,0 +1,6 @@
+package com.moneymate.moneymate.ui.finance.component
+
+data class NewsContainerData(
+    val publisher: String,
+    val articles: List<ArticleData>,
+)

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainerData.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsContainerData.kt
@@ -1,6 +1,6 @@
 package com.moneymate.moneymate.ui.finance.component
 
 data class NewsContainerData(
-    val publisher: String,
+    val publisher: PublisherData,
     val articles: List<ArticleData>,
 )

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsItem.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsItem.kt
@@ -1,0 +1,60 @@
+package com.moneymate.moneymate.ui.finance.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@Composable
+fun NewsItem(
+    modifier: Modifier = Modifier,
+    title: String,
+    url: String,
+    isLastArticle: Boolean,
+    onClick: () -> Unit,
+) {
+    val dividerColor = MoneyMateTheme.colors.lightGray
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .drawBehind {
+                if (!isLastArticle) {
+                    drawLine(
+                        color = dividerColor,
+                        start = Offset(0f, size.height),
+                        end = Offset(size.width, size.height),
+                        strokeWidth = 1.dp.toPx()
+                    )
+                }
+            }
+            .clickable { onClick() }
+            .padding(vertical = 10.dp)
+    ) {
+        Text(
+            text = title,
+            style = TextStyle(
+                fontSize = 18.sp,
+                fontFamily = FontFamily(Font(R.font.pretendard_medium)),
+                color = MoneyMateTheme.colors.black
+            ),
+            maxLines = 1,
+            overflow = TextOverflow.Clip,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsItem.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/NewsItem.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moneymate.moneymate.R
@@ -25,7 +24,7 @@ fun NewsItem(
     title: String,
     url: String,
     isLastArticle: Boolean,
-    onClick: () -> Unit,
+    onArticleClick: (String) -> Unit,
 ) {
     val dividerColor = MoneyMateTheme.colors.lightGray
 
@@ -42,7 +41,7 @@ fun NewsItem(
                     )
                 }
             }
-            .clickable { onClick() }
+            .clickable { onArticleClick(url) } //클릭했을 때 기사 웹뷰로 넘어감
             .padding(vertical = 10.dp)
     ) {
         Text(

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/PublisherData.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/PublisherData.kt
@@ -1,0 +1,9 @@
+package com.moneymate.moneymate.ui.finance.component
+
+data class PublisherData(
+    val enum : String,
+    val publisherName : String,
+    val introduction : String,
+    val imageUrl : String,
+    val category: List<String>,
+)

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/PublisherData.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/PublisherData.kt
@@ -5,5 +5,10 @@ data class PublisherData(
     val publisherName : String,
     val introduction : String,
     val imageUrl : String,
-    val category: List<String>,
+    val category: List<CategoryData>,
+)
+
+data class CategoryData(
+    val categoryName : String,
+    val isSelected : Boolean,
 )

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/PublisherProvider.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/PublisherProvider.kt
@@ -12,7 +12,7 @@ object PublisherProvider {
         ),
         PublisherData(
             "MK",
-            "메일경제",
+            "매일경제",
             "Make Knowledge",
             "",
             listOf("economy", "stock", "realestate", "business")
@@ -60,4 +60,7 @@ object PublisherProvider {
             listOf(" ")
         ),
     )
+
+    //enum - 언론사 이름 매칭에 용이하도록
+    val publisherMap: Map<String, PublisherData> = publisherList.associateBy { it.enum }
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/PublisherProvider.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/PublisherProvider.kt
@@ -8,57 +8,69 @@ object PublisherProvider {
             "한국경제",
             "세상을 보는 균형",
             " ",
-            listOf("economy", "stock", "realestate")
+            listOf(
+                CategoryData("economy",true),
+                CategoryData("stock", false),
+                CategoryData("realestate", false))
         ),
         PublisherData(
             "MK",
             "매일경제",
             "Make Knowledge",
             "",
-            listOf("economy", "stock", "realestate", "business")
+            listOf(
+                CategoryData("economy",true),
+                CategoryData("stock", false),
+                CategoryData("realestate", false),
+                CategoryData("business", false))
         ),
         PublisherData(
             "FNN",
             "파이낸셜뉴스",
             "first-class 경제신문",
             "",
-            listOf("economy", "stock", "finance", "realestate")
+            listOf(
+                CategoryData("economy",true),
+                CategoryData("stock", false),
+                CategoryData("finance", false),
+                CategoryData("realestate", false))
         ),
         PublisherData(
             "YN",
             "연합뉴스",
             "내 손 안의 뉴스",
             "",
-            listOf("economy")
+            listOf(CategoryData("economy",true))
         ),
         PublisherData(
             "CN",
             "조선일보",
             "Facts First:언제나 당신 손에",
             "",
-            listOf("economy")
+            listOf(CategoryData("economy",true))
         ),
         PublisherData(
             "HG",
             "한겨레",
             "세상을 보는 정직한 눈",
             "",
-            listOf("economy")
+            listOf(CategoryData("economy",true), )
         ),
         PublisherData(
             "YF",
             "Yahoo Finance",
             "Your #1 Finance Destination",
             "",
-            listOf(" ") //영문 표기 되도록 빈칸 넘겨줄거임
+            listOf(CategoryData("economy",true), ) //영문 표기 되도록 빈칸 넘겨줄거임
         ),
         PublisherData(
             "FT",
             "Financial Times",
             "We live in Financial Times",
             "",
-            listOf(" ")
-        ),
+            listOf(CategoryData("economy",true),
+            ),
+        )
     )
 
     //enum - 언론사 이름 매칭에 용이하도록

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/PublisherProvider.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/PublisherProvider.kt
@@ -1,0 +1,63 @@
+package com.moneymate.moneymate.ui.finance.component
+
+//전역으로 선언. 언론사 리스트
+object PublisherProvider {
+    val publisherList = listOf(
+        PublisherData(
+            "HK",
+            "한국경제",
+            "세상을 보는 균형",
+            " ",
+            listOf("economy", "stock", "realestate")
+        ),
+        PublisherData(
+            "MK",
+            "메일경제",
+            "Make Knowledge",
+            "",
+            listOf("economy", "stock", "realestate", "business")
+        ),
+        PublisherData(
+            "FNN",
+            "파이낸셜뉴스",
+            "first-class 경제신문",
+            "",
+            listOf("economy", "stock", "finance", "realestate")
+        ),
+        PublisherData(
+            "YN",
+            "연합뉴스",
+            "내 손 안의 뉴스",
+            "",
+            listOf("economy")
+        ),
+        PublisherData(
+            "CN",
+            "조선일보",
+            "Facts First:언제나 당신 손에",
+            "",
+            listOf("economy")
+        ),
+        PublisherData(
+            "HG",
+            "한겨레",
+            "세상을 보는 정직한 눈",
+            "",
+            listOf("economy")
+        ),
+        PublisherData(
+            "YF",
+            "Yahoo Finance",
+            "Your #1 Finance Destination",
+            "",
+            listOf(" ") //영문 표기 되도록 빈칸 넘겨줄거임
+        ),
+        PublisherData(
+            "FT",
+            "Financial Times",
+            "We live in Financial Times",
+            "",
+            listOf(" ")
+        ),
+    )
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/FinanceScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/FinanceScreen.kt
@@ -1,29 +1,90 @@
 package com.moneymate.moneymate.ui.finance.screen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.moneymate.moneymate.R
 import com.moneymate.moneymate.ui.asset.AssetViewModel
+import com.moneymate.moneymate.ui.common.MoneyMateMenuButton
 import com.moneymate.moneymate.ui.finance.FinanceViewModel
 import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 
 @Composable
 fun FinanceScreen(
     modifier: Modifier = Modifier,
-    viewModel: FinanceViewModel = hiltViewModel()
+    onNewsClick: () -> Unit,
+    viewModel: FinanceViewModel = hiltViewModel(),
 ) {
-    Column(modifier = modifier.fillMaxSize()) {
-        Text(
-            text = "FinanceScreen",
-            style = MoneyMateTheme.typography.head_02_B_20,
-            color = MoneyMateTheme.colors.black
-        )
-        Spacer(modifier = Modifier.size(10.dp))
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF5F5F5))
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Card(
+            modifier = Modifier
+                .height(250.dp)
+                .width(360.dp),
+            shape = RoundedCornerShape(20.dp),
+            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MoneyMateTheme.colors.white
+            )
+
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = 22.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "오늘의 경제 이슈",
+                    color = MoneyMateTheme.colors.darkGray,
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
+                        fontSize = 20.sp
+                    )
+                )
+                Spacer(
+                    modifier = Modifier
+                        .padding(top = 21.dp)
+                        .width(312.5.dp)
+                        .height(1.dp)
+                        .background(color = MoneyMateTheme.colors.deepBlue)
+                )
+            }
+        }
+        MoneyMateMenuButton("경제 뉴스 조회", 67, onNewsClick)
+        MoneyMateMenuButton("주식 정보", 67, onNewsClick) /*나중에 함수 바꾸기*/
+        MoneyMateMenuButton("은행 상품 정보", 67, onNewsClick)
+        MoneyMateMenuButton("주택 청약 정보", 67, onNewsClick)
     }
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsArticleScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsArticleScreen.kt
@@ -2,19 +2,12 @@ package com.moneymate.moneymate.ui.finance.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,49 +23,24 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.moneymate.moneymate.R
 import com.moneymate.moneymate.ui.finance.FinanceViewModel
-import com.moneymate.moneymate.ui.finance.component.ArticleData
-import com.moneymate.moneymate.ui.finance.component.NewsContainer
-import com.moneymate.moneymate.ui.finance.component.NewsContainerData
-import com.moneymate.moneymate.ui.finance.component.PublisherProvider
 import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 
 @Composable
-fun NewsScreen(
-    modifier: Modifier = Modifier,
+fun NewsArticleScreen(
+    modifier: Modifier,
+    url: String,
     viewModel: FinanceViewModel = hiltViewModel(),
-    onAddClick: (String) -> Unit,
-    onArticleClick: (String) -> Unit,
     onNavigateBack: () -> Unit,
 ) {
-    val scrollState = rememberScrollState()
-
-    val newsList = viewModel.newsList.value
-    val newsGroupedByPublisher = newsList.groupBy { it.publisher }
-
-    val newsData = newsGroupedByPublisher.mapNotNull { (publisherCode, articles) ->
-        val publisherData = PublisherProvider.publisherMap[publisherCode]
-        publisherData?.let {
-            NewsContainerData(
-                publisher = it,
-                articles = articles.map { article ->
-                    ArticleData(article.title, article.link)
-
-                }
-            )
-        }
-    }
-
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(scrollState)
-            .background(MoneyMateTheme.colors.backgroundWhite)
+            .background(MoneyMateTheme.colors.white)
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .background(MoneyMateTheme.colors.white)
                 .padding(horizontal = 16.dp, vertical = 20.dp)
         ) {
             Box(
@@ -102,26 +70,16 @@ fun NewsScreen(
             }
             Box(modifier = Modifier.weight(1f))
         }
-        Spacer(
-            modifier = Modifier
-                .height(20.dp)
-                .fillMaxWidth()
-        )
 
-        LazyColumn(
-            verticalArrangement = Arrangement.spacedBy(20.dp),
-            modifier = Modifier.weight(1f)
-        ) {
-            items(newsData) { articles ->
-                NewsContainer(
-                    news = articles,
-                    onAddClick = {
-                        onAddClick(articles.publisher.enum)
-                    },
-                    onArticleClick = onArticleClick
-                )
-            }
-        }
+        //TODO 웹뷰 자리
+        Text(
+            text = url,
+            color = MoneyMateTheme.colors.darkGray,
+            style = TextStyle(
+                fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
+                fontSize = 20.sp
+            )
+        )
 
     }
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsOverallScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsOverallScreen.kt
@@ -1,0 +1,145 @@
+package com.moneymate.moneymate.ui.finance.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.ui.finance.FinanceViewModel
+import com.moneymate.moneymate.ui.finance.component.NewsContainer
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@Composable
+fun NewsOverallScreen(
+    modifier: Modifier = Modifier,
+    navController: NavHostController,
+    viewModel: FinanceViewModel = hiltViewModel(),
+    onNavigateBack: () -> Boolean,
+) {
+    val scrollState = rememberScrollState()
+
+    val dummyNewsSections = listOf(
+        listOf(
+            "20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070",
+            "지방 집주인 서울 아파트 산다",
+            "놀아도 월 198만 원 받는데…",
+            "골프 대신 해외주식? 새로운 트렌드"
+        ),
+        listOf(
+            "청년 투자 심리 위축",
+            "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
+            "연금 개편안, 당신의 은퇴는?",
+            "전세 사기 피해자들 구제책은?"
+        ),
+        listOf(
+            "청년 투자 심리 위축",
+            "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
+            "연금 개편안, 당신의 은퇴는?",
+            "전세 사기 피해자들 구제책은?"
+        ),
+        listOf(
+            "청년 투자 심리 위축",
+            "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
+            "연금 개편안, 당신의 은퇴는?",
+            "전세 사기 피해자들 구제책은?"
+        ),
+        listOf(
+            "청년 투자 심리 위축",
+            "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
+            "연금 개편안, 당신의 은퇴는?",
+            "전세 사기 피해자들 구제책은?"
+        ),
+        listOf(
+            "청년 투자 심리 위축",
+            "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
+            "연금 개편안, 당신의 은퇴는?",
+            "전세 사기 피해자들 구제책은?"
+        )
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState)
+            .background(MoneyMateTheme.colors.backgroundWhite)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MoneyMateTheme.colors.white)
+                .padding(horizontal = 16.dp, vertical = 20.dp)
+        ) {
+            Box(
+                modifier = Modifier.weight(1f),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_mypage_arrow),
+                    contentDescription = "뒤로가기",
+                    modifier = Modifier
+                        .rotate(180f)
+                        .clickable { onNavigateBack() }
+                )
+            }
+            Box(
+                modifier = Modifier.weight(2f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "경제 뉴스 조회",
+                    color = MoneyMateTheme.colors.darkGray,
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
+                        fontSize = 20.sp
+                    )
+                )
+            }
+            Box(modifier = Modifier.weight(1f))
+        }
+        Spacer(modifier = Modifier
+            .height(20.dp)
+            .fillMaxWidth())
+
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            modifier = Modifier.weight(1f)
+        ) {
+            items(dummyNewsSections) { articles ->
+                NewsContainer(
+                    publisher = "한국경제",
+                    articles = articles,
+                    onAddClick = {
+                        // TODO: 웹뷰 이동 처리
+                    }
+                )
+            }
+        }
+
+    }
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsPublisherHomeScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsPublisherHomeScreen.kt
@@ -14,9 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,20 +28,18 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
 import com.moneymate.moneymate.R
 import com.moneymate.moneymate.ui.finance.FinanceViewModel
 import com.moneymate.moneymate.ui.finance.component.NewsCategoryButton
-import com.moneymate.moneymate.ui.finance.component.NewsContainer
 import com.moneymate.moneymate.ui.finance.component.NewsItem
 import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 
 @Composable
 fun NewsPublisherHomeScreen(
     modifier: Modifier,
-    navController: NavHostController,
+    publisher : String,
     viewModel: FinanceViewModel = hiltViewModel(),
-    onNavigateBack: () -> Boolean,
+    onNavigateBack: () -> Unit,
 ) {
     val dummyArticle = listOf(
         "20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070",
@@ -121,7 +117,7 @@ fun NewsPublisherHomeScreen(
             verticalArrangement = Arrangement.Center
         ) {
             Text(
-                text = "한국경제",
+                text = publisher,
                 style = TextStyle(
                     fontFamily = FontFamily(Font(R.font.pretendard_bold)),
                     fontSize = 32.sp,
@@ -173,7 +169,7 @@ fun NewsPublisherHomeScreen(
                     title = article,
                     url = "",
                     isLastArticle = isLast,
-                    onClick = {
+                    onArticleClick = {
                         // TODO
                     }
                 )

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsPublisherHomeScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsPublisherHomeScreen.kt
@@ -146,10 +146,10 @@ fun NewsPublisherHomeScreen(
                     .horizontalScroll(scrollState),
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                NewsCategoryButton("경제", true) { }
-                NewsCategoryButton("증권", false) { }
-                NewsCategoryButton("금융", false) { }
-                NewsCategoryButton("부동산", false) { }
+                NewsCategoryButton("economy", true) { }
+                NewsCategoryButton("stock", false) { }
+                NewsCategoryButton("finance", false) { }
+                NewsCategoryButton("business", false) { }
             }
             Spacer(Modifier.width(33.dp))
         }

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsPublisherHomeScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsPublisherHomeScreen.kt
@@ -45,8 +45,9 @@ import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 @Composable
 fun NewsPublisherHomeScreen(
     modifier: Modifier,
-    publisher : String,
+    publisher: String,
     viewModel: FinanceViewModel = hiltViewModel(),
+    onArticleClick: (String) -> Unit,
     onNavigateBack: () -> Unit,
 ) {
     val publisherData = PublisherProvider.publisherList.find { it.enum == publisher }
@@ -67,7 +68,7 @@ fun NewsPublisherHomeScreen(
     val categoryNews = viewModel.categoryNewsList.value
     val scrollState = rememberScrollState()
 
-    if (publisherData != null){
+    if (publisherData != null) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -136,32 +137,26 @@ fun NewsPublisherHomeScreen(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .padding(start = 33.dp, end = 33.dp)
                     .background(MoneyMateTheme.colors.white)
+                    .horizontalScroll(scrollState),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Spacer(Modifier.width(33.dp))
-                Row (
-                    modifier = Modifier
-                        .horizontalScroll(scrollState),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp)
-                ) {
-                    if (categoryState != null) {
-                        categoryState.forEachIndexed { index, category ->
-                            NewsCategoryButton(
-                                category = category.categoryName,
-                                isSelected = category.isSelected,
-                                onClick = {
-                                    categoryState.replaceAll { it.copy(isSelected = false) }
-                                    categoryState[index] = category.copy(isSelected = true)
+                if (categoryState != null) {
+                    categoryState.forEachIndexed { index, category ->
+                        NewsCategoryButton(
+                            category = category.categoryName,
+                            isSelected = category.isSelected,
+                            onClick = {
+                                categoryState.replaceAll { it.copy(isSelected = false) }
+                                categoryState[index] = category.copy(isSelected = true)
 
-                                    // TODO: 이 지점에서 선택된 카테고리에 따라 API 요청 가능
-                                    viewModel.getCategoryNews(publisher, category.categoryName)
+                                viewModel.getCategoryNews(publisher, category.categoryName)
 
-                                }
-                            )
-                        }
+                            }
+                        )
                     }
                 }
-                Spacer(Modifier.width(33.dp))
             }
 
             Spacer(modifier = Modifier.height(17.dp))
@@ -180,7 +175,7 @@ fun NewsPublisherHomeScreen(
                         url = article.link,
                         isLastArticle = isLast,
                         onArticleClick = {
-                            // TODO
+                            onArticleClick(article.link)
                         }
                     )
                 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsPublisherHomeScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsPublisherHomeScreen.kt
@@ -1,5 +1,6 @@
 package com.moneymate.moneymate.ui.finance.screen
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -18,6 +19,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -32,6 +37,9 @@ import com.moneymate.moneymate.R
 import com.moneymate.moneymate.ui.finance.FinanceViewModel
 import com.moneymate.moneymate.ui.finance.component.NewsCategoryButton
 import com.moneymate.moneymate.ui.finance.component.NewsItem
+import com.moneymate.moneymate.ui.finance.component.PublisherData
+import com.moneymate.moneymate.ui.finance.component.PublisherProvider
+import com.moneymate.moneymate.ui.finance.component.PublisherProvider.publisherList
 import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 
 @Composable
@@ -41,140 +49,144 @@ fun NewsPublisherHomeScreen(
     viewModel: FinanceViewModel = hiltViewModel(),
     onNavigateBack: () -> Unit,
 ) {
-    val dummyArticle = listOf(
-        "20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070",
-        "지방 집주인 서울 아파트 산다",
-        "놀아도 월 198만 원 받는데…",
-        "골프 대신 해외주식? 새로운 트렌드",
-        "청년 투자 심리 위축",
-        "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
-        "연금 개편안, 당신의 은퇴는?",
-        "전세 사기 피해자들 구제책은?",
-        "20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070",
-        "지방 집주인 서울 아파트 산다",
-        "놀아도 월 198만 원 받는데…",
-        "골프 대신 해외주식? 새로운 트렌드",
-        "청년 투자 심리 위축",
-        "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
-        "연금 개편안, 당신의 은퇴는?",
-        "전세 사기 피해자들 구제책은?",
-        "20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070",
-        "지방 집주인 서울 아파트 산다",
-        "놀아도 월 198만 원 받는데…",
-        "골프 대신 해외주식? 새로운 트렌드",
-        "청년 투자 심리 위축",
-        "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
-        "연금 개편안, 당신의 은퇴는?",
-        "전세 사기 피해자들 구제책은?"
-    )
+    val publisherData = PublisherProvider.publisherList.find { it.enum == publisher }
 
+    val categoryState = remember {
+        publisherData?.category?.toMutableStateList()
+    }
+
+    LaunchedEffect(Unit) {
+        if (!categoryState.isNullOrEmpty()) {
+            val selected = categoryState.firstOrNull { it.isSelected }
+            selected?.let {
+                viewModel.getCategoryNews(publisher, it.categoryName)
+            }
+        }
+    }
+
+    val categoryNews = viewModel.categoryNewsList.value
     val scrollState = rememberScrollState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MoneyMateTheme.colors.white)
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
+    if (publisherData != null){
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 20.dp)
+                .fillMaxSize()
+                .background(MoneyMateTheme.colors.white)
         ) {
-            Box(
-                modifier = Modifier.weight(1f),
-                contentAlignment = Alignment.CenterStart
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 20.dp)
             ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_mypage_arrow),
-                    contentDescription = "뒤로가기",
-                    modifier = Modifier
-                        .rotate(180f)
-                        .clickable { onNavigateBack() }
-                )
+                Box(
+                    modifier = Modifier.weight(1f),
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_mypage_arrow),
+                        contentDescription = "뒤로가기",
+                        modifier = Modifier
+                            .rotate(180f)
+                            .clickable { onNavigateBack() }
+                    )
+                }
+                Box(
+                    modifier = Modifier.weight(2f),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "경제 뉴스 조회",
+                        color = MoneyMateTheme.colors.darkGray,
+                        style = TextStyle(
+                            fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
+                            fontSize = 20.sp
+                        )
+                    )
+                }
+                Box(modifier = Modifier.weight(1f))
             }
-            Box(
-                modifier = Modifier.weight(2f),
-                contentAlignment = Alignment.Center
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(160.dp)
+                    .padding(vertical = 33.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
             ) {
                 Text(
-                    text = "경제 뉴스 조회",
-                    color = MoneyMateTheme.colors.darkGray,
+                    text = publisherData.publisherName,
                     style = TextStyle(
-                        fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
-                        fontSize = 20.sp
+                        fontFamily = FontFamily(Font(R.font.pretendard_bold)),
+                        fontSize = 32.sp,
+                        color = MoneyMateTheme.colors.black
+                    )
+                )
+                Spacer(modifier = Modifier.height(14.dp))
+                Text(
+                    text = publisherData.introduction,
+                    style = TextStyle(
+                        fontSize = 16.sp,
+                        fontFamily = FontFamily(Font(R.font.pretendard_regular)),
+                        color = MoneyMateTheme.colors.black
                     )
                 )
             }
-            Box(modifier = Modifier.weight(1f))
-        }
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(160.dp)
-                .padding(vertical = 33.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
-        ) {
-            Text(
-                text = publisher,
-                style = TextStyle(
-                    fontFamily = FontFamily(Font(R.font.pretendard_bold)),
-                    fontSize = 32.sp,
-                    color = MoneyMateTheme.colors.black
-                )
-            )
-            Spacer(modifier = Modifier.height(14.dp))
-            Text(
-                text = "성공을 부르는 습관",
-                style = TextStyle(
-                    fontSize = 16.sp,
-                    fontFamily = FontFamily(Font(R.font.pretendard_regular)),
-                    color = MoneyMateTheme.colors.black
-                )
-            )
-        }
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MoneyMateTheme.colors.white)
-        ) {
-            Spacer(Modifier.width(33.dp))
-            Row (
+            Row(
                 modifier = Modifier
-                    .horizontalScroll(scrollState),
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    .fillMaxWidth()
+                    .background(MoneyMateTheme.colors.white)
             ) {
-                NewsCategoryButton("economy", true) { }
-                NewsCategoryButton("stock", false) { }
-                NewsCategoryButton("finance", false) { }
-                NewsCategoryButton("business", false) { }
-            }
-            Spacer(Modifier.width(33.dp))
-        }
+                Spacer(Modifier.width(33.dp))
+                Row (
+                    modifier = Modifier
+                        .horizontalScroll(scrollState),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    if (categoryState != null) {
+                        categoryState.forEachIndexed { index, category ->
+                            NewsCategoryButton(
+                                category = category.categoryName,
+                                isSelected = category.isSelected,
+                                onClick = {
+                                    categoryState.replaceAll { it.copy(isSelected = false) }
+                                    categoryState[index] = category.copy(isSelected = true)
 
-        Spacer(modifier = Modifier.height(17.dp))
+                                    // TODO: 이 지점에서 선택된 카테고리에 따라 API 요청 가능
+                                    viewModel.getCategoryNews(publisher, category.categoryName)
 
-        LazyColumn(
-            modifier = Modifier
-                .padding(horizontal = 28.dp)
-                .weight(1f)
-        ) {
-            items(dummyArticle.size) { index ->
-                val article = dummyArticle[index]
-                val isLast = index == dummyArticle.lastIndex
-
-                NewsItem(
-                    title = article,
-                    url = "",
-                    isLastArticle = isLast,
-                    onArticleClick = {
-                        // TODO
+                                }
+                            )
+                        }
                     }
-                )
+                }
+                Spacer(Modifier.width(33.dp))
             }
-        }
 
+            Spacer(modifier = Modifier.height(17.dp))
+
+            LazyColumn(
+                modifier = Modifier
+                    .padding(horizontal = 28.dp)
+                    .weight(1f)
+            ) {
+                items(categoryNews.size) { index ->
+                    val article = categoryNews[index]
+                    val isLast = index == categoryNews.lastIndex
+
+                    NewsItem(
+                        title = article.title,
+                        url = article.link,
+                        isLastArticle = isLast,
+                        onArticleClick = {
+                            // TODO
+                        }
+                    )
+                }
+            }
+
+        }
     }
+
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsPublisherHomeScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsPublisherHomeScreen.kt
@@ -1,0 +1,184 @@
+package com.moneymate.moneymate.ui.finance.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.ui.finance.FinanceViewModel
+import com.moneymate.moneymate.ui.finance.component.NewsCategoryButton
+import com.moneymate.moneymate.ui.finance.component.NewsContainer
+import com.moneymate.moneymate.ui.finance.component.NewsItem
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@Composable
+fun NewsPublisherHomeScreen(
+    modifier: Modifier,
+    navController: NavHostController,
+    viewModel: FinanceViewModel = hiltViewModel(),
+    onNavigateBack: () -> Boolean,
+) {
+    val dummyArticle = listOf(
+        "20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070",
+        "지방 집주인 서울 아파트 산다",
+        "놀아도 월 198만 원 받는데…",
+        "골프 대신 해외주식? 새로운 트렌드",
+        "청년 투자 심리 위축",
+        "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
+        "연금 개편안, 당신의 은퇴는?",
+        "전세 사기 피해자들 구제책은?",
+        "20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070",
+        "지방 집주인 서울 아파트 산다",
+        "놀아도 월 198만 원 받는데…",
+        "골프 대신 해외주식? 새로운 트렌드",
+        "청년 투자 심리 위축",
+        "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
+        "연금 개편안, 당신의 은퇴는?",
+        "전세 사기 피해자들 구제책은?",
+        "20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070",
+        "지방 집주인 서울 아파트 산다",
+        "놀아도 월 198만 원 받는데…",
+        "골프 대신 해외주식? 새로운 트렌드",
+        "청년 투자 심리 위축",
+        "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
+        "연금 개편안, 당신의 은퇴는?",
+        "전세 사기 피해자들 구제책은?"
+    )
+
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MoneyMateTheme.colors.white)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 20.dp)
+        ) {
+            Box(
+                modifier = Modifier.weight(1f),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_mypage_arrow),
+                    contentDescription = "뒤로가기",
+                    modifier = Modifier
+                        .rotate(180f)
+                        .clickable { onNavigateBack() }
+                )
+            }
+            Box(
+                modifier = Modifier.weight(2f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "경제 뉴스 조회",
+                    color = MoneyMateTheme.colors.darkGray,
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
+                        fontSize = 20.sp
+                    )
+                )
+            }
+            Box(modifier = Modifier.weight(1f))
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(160.dp)
+                .padding(vertical = 33.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "한국경제",
+                style = TextStyle(
+                    fontFamily = FontFamily(Font(R.font.pretendard_bold)),
+                    fontSize = 32.sp,
+                    color = MoneyMateTheme.colors.black
+                )
+            )
+            Spacer(modifier = Modifier.height(14.dp))
+            Text(
+                text = "성공을 부르는 습관",
+                style = TextStyle(
+                    fontSize = 16.sp,
+                    fontFamily = FontFamily(Font(R.font.pretendard_regular)),
+                    color = MoneyMateTheme.colors.black
+                )
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MoneyMateTheme.colors.white)
+        ) {
+            Spacer(Modifier.width(33.dp))
+            Row (
+                modifier = Modifier
+                    .horizontalScroll(scrollState),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                NewsCategoryButton("경제", true) { }
+                NewsCategoryButton("증권", false) { }
+                NewsCategoryButton("금융", false) { }
+                NewsCategoryButton("부동산", false) { }
+            }
+            Spacer(Modifier.width(33.dp))
+        }
+
+        Spacer(modifier = Modifier.height(17.dp))
+
+        LazyColumn(
+            modifier = Modifier
+                .padding(horizontal = 28.dp)
+                .weight(1f)
+        ) {
+            items(dummyArticle.size) { index ->
+                val article = dummyArticle[index]
+                val isLast = index == dummyArticle.lastIndex
+
+                NewsItem(
+                    title = article,
+                    url = "",
+                    isLastArticle = isLast,
+                    onClick = {
+                        // TODO
+                    }
+                )
+            }
+        }
+
+    }
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsScreen.kt
@@ -31,19 +31,51 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.moneymate.moneymate.R
 import com.moneymate.moneymate.ui.finance.FinanceViewModel
+import com.moneymate.moneymate.ui.finance.component.ArticleData
 import com.moneymate.moneymate.ui.finance.component.NewsContainer
+import com.moneymate.moneymate.ui.finance.component.NewsContainerData
 import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 
 @Composable
-fun NewsOverallScreen(
+fun NewsScreen(
     modifier: Modifier = Modifier,
-    navController: NavHostController,
     viewModel: FinanceViewModel = hiltViewModel(),
-    onNavigateBack: () -> Boolean,
+    onAddClick : (String) -> Unit,
+    onNavigateBack: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
 
-    val dummyNewsSections = listOf(
+    val dummyNewsData = listOf(
+        NewsContainerData("pulisher",
+            listOf(
+                ArticleData("20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070", ""),
+                ArticleData("20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070", ""),
+                ArticleData("20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070", ""),
+                ArticleData("20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070", ""))
+        ), NewsContainerData("secondPublisher",
+            listOf(ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
+                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
+                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
+                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ","")
+            )
+        ),
+        NewsContainerData("secondPublisher",
+            listOf(ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
+                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
+                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
+                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ","")
+            )
+        ),
+        NewsContainerData("secondPublisher",
+            listOf(ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
+                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
+                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
+                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ","")
+            )
+        ),
+    )
+
+/*    val dummyNewsSections = listOf(
         listOf(
             "20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070",
             "지방 집주인 서울 아파트 산다",
@@ -80,7 +112,7 @@ fun NewsOverallScreen(
             "연금 개편안, 당신의 은퇴는?",
             "전세 사기 피해자들 구제책은?"
         )
-    )
+    )*/
 
     Column(
         modifier = Modifier
@@ -130,13 +162,13 @@ fun NewsOverallScreen(
             verticalArrangement = Arrangement.spacedBy(20.dp),
             modifier = Modifier.weight(1f)
         ) {
-            items(dummyNewsSections) { articles ->
+            items(dummyNewsData) { articles ->
                 NewsContainer(
-                    publisher = "한국경제",
-                    articles = articles,
+                    news = articles,
                     onAddClick = {
-                        // TODO: 웹뷰 이동 처리
-                    }
+                        onAddClick(articles.publisher)
+                    },
+                    onArticleClick = { }
                 )
             }
         }

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsScreen.kt
@@ -112,9 +112,9 @@ fun NewsScreen(
                 NewsContainer(
                     news = articles,
                     onAddClick = {
-                        //onAddClick(articles.publisher) TODO 오류 수정
+                        onAddClick(articles.publisher.enum)
                     },
-                    onArticleClick = { }
+                    onArticleClick = { } //TODO?
                 )
             }
         }

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsScreen.kt
@@ -28,12 +28,12 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
 import com.moneymate.moneymate.R
 import com.moneymate.moneymate.ui.finance.FinanceViewModel
 import com.moneymate.moneymate.ui.finance.component.ArticleData
 import com.moneymate.moneymate.ui.finance.component.NewsContainer
 import com.moneymate.moneymate.ui.finance.component.NewsContainerData
+import com.moneymate.moneymate.ui.finance.component.PublisherProvider
 import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 
 @Composable
@@ -45,74 +45,20 @@ fun NewsScreen(
 ) {
     val scrollState = rememberScrollState()
 
-    val dummyNewsData = listOf(
-        NewsContainerData("pulisher",
-            listOf(
-                ArticleData("20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070", ""),
-                ArticleData("20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070", ""),
-                ArticleData("20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070", ""),
-                ArticleData("20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070", ""))
-        ), NewsContainerData("secondPublisher",
-            listOf(ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
-                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
-                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
-                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ","")
-            )
-        ),
-        NewsContainerData("secondPublisher",
-            listOf(ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
-                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
-                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
-                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ","")
-            )
-        ),
-        NewsContainerData("secondPublisher",
-            listOf(ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
-                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
-                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",""),
-                ArticleData("부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ","")
-            )
-        ),
-    )
+    val newsList = viewModel.newsList.value
+    val newsGroupedByPublisher = newsList.groupBy { it.publisher }
 
-/*    val dummyNewsSections = listOf(
-        listOf(
-            "20년 살던 집 팔아 수십억 벌었다…강남 떠나는 5070",
-            "지방 집주인 서울 아파트 산다",
-            "놀아도 월 198만 원 받는데…",
-            "골프 대신 해외주식? 새로운 트렌드"
-        ),
-        listOf(
-            "청년 투자 심리 위축",
-            "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
-            "연금 개편안, 당신의 은퇴는?",
-            "전세 사기 피해자들 구제책은?"
-        ),
-        listOf(
-            "청년 투자 심리 위축",
-            "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
-            "연금 개편안, 당신의 은퇴는?",
-            "전세 사기 피해자들 구제책은?"
-        ),
-        listOf(
-            "청년 투자 심리 위축",
-            "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
-            "연금 개편안, 당신의 은퇴는?",
-            "전세 사기 피해자들 구제책은?"
-        ),
-        listOf(
-            "청년 투자 심리 위축",
-            "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
-            "연금 개편안, 당신의 은퇴는?",
-            "전세 사기 피해자들 구제책은?"
-        ),
-        listOf(
-            "청년 투자 심리 위축",
-            "부동산 시장 급변, 어떻게 대응할까ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ",
-            "연금 개편안, 당신의 은퇴는?",
-            "전세 사기 피해자들 구제책은?"
-        )
-    )*/
+    val newsData = newsGroupedByPublisher.mapNotNull { (publisherCode, articles) ->
+        val publisherData = PublisherProvider.publisherMap[publisherCode]
+        publisherData?.let {
+            NewsContainerData(
+                publisher = it,
+                articles = articles.map { article ->
+                    ArticleData(article.title, article.link)
+                }
+            )
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -162,11 +108,11 @@ fun NewsScreen(
             verticalArrangement = Arrangement.spacedBy(20.dp),
             modifier = Modifier.weight(1f)
         ) {
-            items(dummyNewsData) { articles ->
+            items(newsData) { articles ->
                 NewsContainer(
                     news = articles,
                     onAddClick = {
-                        onAddClick(articles.publisher)
+                        //onAddClick(articles.publisher) TODO 오류 수정
                     },
                     onArticleClick = { }
                 )

--- a/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/ManageScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/ManageScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.moneymate.moneymate.R
+import com.moneymate.moneymate.ui.common.MoneyMateMenuButton
 import com.moneymate.moneymate.ui.finance.FinanceViewModel
 import com.moneymate.moneymate.ui.manage.ManageViewModel
 import com.moneymate.moneymate.ui.theme.MoneyMateTheme
@@ -46,49 +47,8 @@ fun ManageScreen(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        MenuCard(text = "노후 설계 시뮬레이션", onRetireClick)
-        MenuCard(text = "또래 자산 통계 조회하기", onRetireClick) /*나중에 함수 바꾸기*/
-        MenuCard(text = "자산 변동 통계 조회하기", onRetireClick)
-    }
-}
-
-@Composable
-fun MenuCard(
-    text: String,
-    onClick : () ->Unit
-) {
-    Card(
-        modifier = Modifier
-            .height(67.dp)
-            .width(360.dp)
-            .clickable {onClick()},
-        shape = RoundedCornerShape(20.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MoneyMateTheme.colors.white
-        )
-
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(start = 29.dp, end = 21.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(
-                text = text,
-                color = MoneyMateTheme.colors.darkGray,
-                style = TextStyle(
-                    fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
-                    fontSize = 20.sp
-                )
-            )
-            Icon(
-                painter = painterResource(id = R.drawable.ic_mypage_arrow),
-                contentDescription = "화살표 아이콘",
-                tint = Color.Gray
-            )
-        }
+        MoneyMateMenuButton("노후 설계 시뮬레이션", 67, onRetireClick)
+        MoneyMateMenuButton("또래 자산 통계 조회하기", 67, onRetireClick) /*나중에 함수 바꾸기*/
+        MoneyMateMenuButton("자산 변동 통계 조회하기", 67, onRetireClick)
     }
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
@@ -98,8 +98,8 @@ fun MoneyMateNavGraph(
             route = Route.News.route,
         ) { NewsScreen(
                 modifier = modifier,
-                onAddClick = { publisher ->
-                    navController.navigate("${Route.NewsPublisherHome.route}/$publisher")
+                onAddClick = { enum ->
+                    navController.navigate("${Route.NewsPublisherHome.route}/$enum")
                 },
                 onNavigateBack = {
                     navController.navigateUp()
@@ -108,9 +108,9 @@ fun MoneyMateNavGraph(
         }
         //언론사별 홈 화면
         composable (
-            route = "${Route.NewsPublisherHome.route}/{publisher}",
+            route = "${Route.NewsPublisherHome.route}/{enum}",
         ) { backStackEntry ->
-            val publisher = backStackEntry.arguments?.getString("publisher") ?: ""
+            val publisher = backStackEntry.arguments?.getString("enum") ?: ""
             NewsPublisherHomeScreen(
                 modifier = modifier,
                 publisher = publisher,

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
@@ -11,6 +11,8 @@ import com.moneymate.moneymate.ui.asset.screen.AddAssetScreen
 import com.moneymate.moneymate.ui.asset.screen.HomeScreen
 import com.moneymate.moneymate.ui.asset.screen.TransactionHistoryScreen
 import com.moneymate.moneymate.ui.finance.screen.FinanceScreen
+import com.moneymate.moneymate.ui.finance.screen.NewsPublisherHomeScreen
+import com.moneymate.moneymate.ui.finance.screen.NewsScreen
 import com.moneymate.moneymate.ui.manage.screen.ManageScreen
 import com.moneymate.moneymate.ui.mypage.screen.MyPageScreen
 import kotlinx.serialization.json.Json
@@ -88,7 +90,33 @@ fun MoneyMateNavGraph(
         composable(route = Route.Finance.route) {
             FinanceScreen(
                 modifier = modifier,
-                onNewsClick = {}
+                onNewsClick = { navController.navigate(Route.News.route) }
+            )
+        }
+        //경제뉴스 조회 화면
+        composable (
+            route = Route.News.route,
+        ) { NewsScreen(
+                modifier = modifier,
+                onAddClick = { publisher ->
+                    navController.navigate("${Route.NewsPublisherHome.route}/$publisher")
+                },
+                onNavigateBack = {
+                    navController.navigateUp()
+                }
+            )
+        }
+        //언론사별 홈 화면
+        composable (
+            route = "${Route.NewsPublisherHome.route}/{publisher}",
+        ) { backStackEntry ->
+            val publisher = backStackEntry.arguments?.getString("publisher") ?: ""
+            NewsPublisherHomeScreen(
+                modifier = modifier,
+                publisher = publisher,
+                onNavigateBack = {
+                    navController.navigateUp()
+                }
             )
         }
 

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
@@ -87,7 +87,8 @@ fun MoneyMateNavGraph(
         /* 금융 정보 */
         composable(route = Route.Finance.route) {
             FinanceScreen(
-                modifier = modifier
+                modifier = modifier,
+                onNewsClick = {}
             )
         }
 

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
@@ -11,11 +11,14 @@ import com.moneymate.moneymate.ui.asset.screen.AddAssetScreen
 import com.moneymate.moneymate.ui.asset.screen.HomeScreen
 import com.moneymate.moneymate.ui.asset.screen.TransactionHistoryScreen
 import com.moneymate.moneymate.ui.finance.screen.FinanceScreen
+import com.moneymate.moneymate.ui.finance.screen.NewsArticleScreen
 import com.moneymate.moneymate.ui.finance.screen.NewsPublisherHomeScreen
 import com.moneymate.moneymate.ui.finance.screen.NewsScreen
 import com.moneymate.moneymate.ui.manage.screen.ManageScreen
 import com.moneymate.moneymate.ui.mypage.screen.MyPageScreen
 import kotlinx.serialization.json.Json
+import java.net.URLDecoder
+import java.net.URLEncoder
 
 @Composable
 fun MoneyMateNavGraph(
@@ -101,6 +104,10 @@ fun MoneyMateNavGraph(
                 onAddClick = { enum ->
                     navController.navigate("${Route.NewsPublisherHome.route}/$enum")
                 },
+                onArticleClick = { url ->
+                    val encodedUrl = URLEncoder.encode(url, "UTF-8")
+                    navController.navigate("${Route.NewsArticle.route}/$encodedUrl")
+                },
                 onNavigateBack = {
                     navController.navigateUp()
                 }
@@ -114,6 +121,24 @@ fun MoneyMateNavGraph(
             NewsPublisherHomeScreen(
                 modifier = modifier,
                 publisher = publisher,
+                onArticleClick = { url ->
+                    val encodedUrl = URLEncoder.encode(url, "UTF-8")
+                    navController.navigate("${Route.NewsArticle.route}/$encodedUrl")
+                },
+                onNavigateBack = {
+                    navController.navigateUp()
+                }
+            )
+        }
+        //기사 화면
+        composable (
+            route = "${Route.NewsArticle.route}/{url}",
+        ) { backStackEntry ->
+            val encodedUrl = backStackEntry.arguments?.getString("url") ?: ""
+            val url = URLDecoder.decode(encodedUrl, "UTF-8")
+            NewsArticleScreen (
+                modifier = modifier,
+                url = url,
                 onNavigateBack = {
                     navController.navigateUp()
                 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
@@ -17,6 +17,8 @@ sealed class Route(val route: String){
 
     // 금융 정보
     object Finance: Route(route = "finance")
+    object News : Route(route = "news")
+    object NewsPublisherHome : Route(route = "news/publisher")
 
     // 자산 관리
     object Manage: Route(route = "manage")

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
@@ -19,6 +19,7 @@ sealed class Route(val route: String){
     object Finance: Route(route = "finance")
     object News : Route(route = "news")
     object NewsPublisherHome : Route(route = "news/publisher")
+    object NewsArticle : Route(route = "news/newsArticle")
 
     // 자산 관리
     object Manage: Route(route = "manage")


### PR DESCRIPTION
## 🚀 이슈번호


## ✏️ 변경사항
- 경제 뉴스 관련 화면 구성
- 경제 뉴스 관련 api 연결

## 📷 스크린
<img width="1080" height="2400" alt="Screenshot_20250720_204253" src="https://github.com/user-attachments/assets/edcbf24b-1b53-4d93-9c54-b1fbd48da404" />
<img width="1080" height="2400" alt="Screenshot_20250720_204307" src="https://github.com/user-attachments/assets/08881b44-8bae-4672-95a7-25d8208d2134" />
<img width="1080" height="2400" alt="Screenshot_20250720_204322" src="https://github.com/user-attachments/assets/81953f7a-3a99-4db0-83f9-24f4dd3ada77" />
<img width="1080" height="2400" alt="Screenshot_20250720_204330" src="https://github.com/user-attachments/assets/d0f81809-898a-45ea-870f-debfcff3c1a5" />
샷


## ✍️ 사용법


## 🎸 기타
