### PR TITLE
[FEAT] WebView 기본 화면 구현, 토큰 재발급 로직 구현

### DIFF
--- a/app/src/main/java/com/moneymate/moneymate/data/dto/auth/request/TokenReissueRequest.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/auth/request/TokenReissueRequest.kt
@@ -1,0 +1,10 @@
+package com.moneymate.moneymate.data.dto.auth.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TokenReissueRequest(
+    @SerialName("refreshToken")
+    val refreshToken: String,
+)

--- a/app/src/main/java/com/moneymate/moneymate/data/dto/auth/response/LoginResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/auth/response/LoginResponse.kt
@@ -5,6 +5,16 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LoginResponse(
+    @SerialName("status")
+    val statue: String,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: TokenResponse,
+)
+
+@Serializable
+data class TokenResponse(
     @SerialName("accessToken")
     val accessToken: String,
     @SerialName("refreshToken")

--- a/app/src/main/java/com/moneymate/moneymate/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/repository/AuthRepository.kt
@@ -42,8 +42,8 @@ class AuthRepository(
             )
         )
         // 로그인 성공 시 토큰 저장
-        tokenManager.saveAccessToken(response.accessToken)
-        tokenManager.saveRefreshToken(response.refreshToken)
+        tokenManager.saveAccessToken(response.data.accessToken)
+        tokenManager.saveRefreshToken(response.data.refreshToken)
         Log.d("AuthRepository", "Access Token: ${tokenManager.getAccessToken().first()}")
         Log.d("AuthRepository", "Refresh Token: ${tokenManager.getRefreshToken().first()}")
     }

--- a/app/src/main/java/com/moneymate/moneymate/data/service/AuthService.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/service/AuthService.kt
@@ -4,7 +4,6 @@ import com.moneymate.moneymate.data.dto.auth.request.IdPhoneCheckRequest
 import com.moneymate.moneymate.data.dto.auth.request.LoginRequest
 import com.moneymate.moneymate.data.dto.auth.request.PhoneVerificationCodeRequest
 import com.moneymate.moneymate.data.dto.auth.request.RegisterRequest
-import com.moneymate.moneymate.data.dto.auth.request.TokenReissueRequest
 import com.moneymate.moneymate.data.dto.auth.response.IdPhoneCheckResponse
 import com.moneymate.moneymate.data.dto.auth.response.LoginResponse
 import com.moneymate.moneymate.data.dto.auth.response.PhoneVerificationCodeResponse
@@ -49,10 +48,4 @@ interface AuthService {
     suspend fun login(
         @Body request: LoginRequest
     ): LoginResponse
-
-    @POST("user/reissue-token")
-    suspend fun reissueAccessToken(
-        @Body request: TokenReissueRequest
-    ): LoginResponse
-
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/service/AuthService.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/service/AuthService.kt
@@ -4,6 +4,7 @@ import com.moneymate.moneymate.data.dto.auth.request.IdPhoneCheckRequest
 import com.moneymate.moneymate.data.dto.auth.request.LoginRequest
 import com.moneymate.moneymate.data.dto.auth.request.PhoneVerificationCodeRequest
 import com.moneymate.moneymate.data.dto.auth.request.RegisterRequest
+import com.moneymate.moneymate.data.dto.auth.request.TokenReissueRequest
 import com.moneymate.moneymate.data.dto.auth.response.IdPhoneCheckResponse
 import com.moneymate.moneymate.data.dto.auth.response.LoginResponse
 import com.moneymate.moneymate.data.dto.auth.response.PhoneVerificationCodeResponse
@@ -49,7 +50,9 @@ interface AuthService {
         @Body request: LoginRequest
     ): LoginResponse
 
-    // TODO: 토큰재발급 로직
-
+    @POST("user/reissue-token")
+    suspend fun reissueAccessToken(
+        @Body request: TokenReissueRequest
+    ): LoginResponse
 
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/service/TokenService.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/service/TokenService.kt
@@ -1,0 +1,13 @@
+package com.moneymate.moneymate.data.service
+
+import com.moneymate.moneymate.data.dto.auth.request.TokenReissueRequest
+import com.moneymate.moneymate.data.dto.auth.response.LoginResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface TokenService {
+    @POST("user/reissue-token")
+    suspend fun reissueAccessToken(
+        @Body request: TokenReissueRequest
+    ): LoginResponse
+} 

--- a/app/src/main/java/com/moneymate/moneymate/di/NetworkModule.kt
+++ b/app/src/main/java/com/moneymate/moneymate/di/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.moneymate.moneymate.di
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.moneymate.moneymate.BuildConfig
 import com.moneymate.moneymate.util.auth.AuthInterceptor
+import com.moneymate.moneymate.util.auth.TokenAuthenticator
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -23,10 +24,12 @@ object NetworkModule {
     fun providesOkHttpClient(
         loggingInterceptor: HttpLoggingInterceptor,
         authInterceptor: AuthInterceptor,
+        tokenAuthenticator: TokenAuthenticator
     ): OkHttpClient =
         OkHttpClient.Builder().apply {
             addInterceptor(loggingInterceptor)
             addInterceptor(authInterceptor)
+            authenticator(tokenAuthenticator)
         }.build()
 
     @Provides

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsArticleScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/screen/NewsArticleScreen.kt
@@ -1,5 +1,8 @@
 package com.moneymate.moneymate.ui.finance.screen
 
+import android.annotation.SuppressLint
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -11,6 +14,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -20,6 +27,7 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.moneymate.moneymate.R
 import com.moneymate.moneymate.ui.finance.FinanceViewModel
@@ -71,15 +79,16 @@ fun NewsArticleScreen(
             Box(modifier = Modifier.weight(1f))
         }
 
-        //TODO 웹뷰 자리
-        Text(
-            text = url,
-            color = MoneyMateTheme.colors.darkGray,
-            style = TextStyle(
-                fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
-                fontSize = 20.sp
-            )
+        // WebView 컴포넌트가 들어갈 자리
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { context ->
+                WebView(context).apply {
+                    webViewClient = WebViewClient()
+                    settings.javaScriptEnabled = true
+                    loadUrl(url)
+                }
+            }
         )
-
     }
 }

--- a/app/src/main/java/com/moneymate/moneymate/util/auth/TokenAuthenticator.kt
+++ b/app/src/main/java/com/moneymate/moneymate/util/auth/TokenAuthenticator.kt
@@ -1,0 +1,66 @@
+package com.moneymate.moneymate.util.auth
+
+import android.util.Log
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.moneymate.moneymate.BuildConfig
+import com.moneymate.moneymate.data.dto.auth.request.TokenReissueRequest
+import com.moneymate.moneymate.data.service.TokenService
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import okhttp3.Authenticator
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import retrofit2.Retrofit
+import javax.inject.Inject
+
+class TokenAuthenticator @Inject constructor(
+    private val tokenManager: TokenManager,
+) : Authenticator {
+    override fun authenticate(route: Route?, response: Response): Request? {
+        // 이미 재시도했던 요청인 경우 null을 반환하여 재시도 중단
+        if (response.request.header("Retry-With-New-Token") != null) {
+            return null
+        }
+
+        return runBlocking {
+            try {
+                val refreshToken = tokenManager.getRefreshToken().first()
+                if (refreshToken == null) {
+                    tokenManager.clearToken()
+                    return@runBlocking null
+                }
+
+                // 토큰 재발급 요청
+                val tokenService = Retrofit.Builder()
+                    .baseUrl(BuildConfig.BASE_URL)
+                    .client(OkHttpClient.Builder().build())
+                    .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
+                    .build()
+                    .create(TokenService::class.java)
+                val tokenResponse = tokenService.reissueAccessToken(
+                    TokenReissueRequest(refreshToken = refreshToken)
+                )
+
+                // 새로운 토큰 저장
+                tokenManager.saveAccessToken(tokenResponse.data.accessToken)
+                tokenManager.saveRefreshToken(tokenResponse.data.refreshToken)
+                Log.d("TokenAuthenticator", "토큰 재발급 성공: ${tokenResponse.data.accessToken}")
+
+                // 기존 요청에 새로운 토큰으로 헤더를 추가하여 재시도
+                response.request.newBuilder()
+                    .header("Authorization", "Bearer ${tokenResponse.data.accessToken}")
+                    .header("Retry-With-New-Token", "true")
+                    .build()
+            } catch (e: Exception) {
+                // 토큰 재발급 실패 시 토큰 클리어
+                Log.d("TokenAuthenticator", "토큰 재발급 실패: ${e.message}")
+                tokenManager.clearToken()
+                null
+            }
+        }
+    }
+} 


### PR DESCRIPTION
## 🚀 이슈번호
- #17 

## ✏️ 변경사항
- 상세 기사 화면에 WebView 컴포넌트 추가
- access token 만료시 refresh token을 통한 재발급 로직 구현

## 📷 스크린샷


## ✍️ 사용법


## 🎸 기타
