### PR TITLE
[ui] 보유주식 조회 화면 ui

### DIFF
--- a/app/src/main/java/com/moneymate/moneymate/data/dto/asset/response/StockListResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/asset/response/StockListResponse.kt
@@ -1,0 +1,36 @@
+package com.moneymate.moneymate.data.dto.asset.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StockListResponse(
+    @SerialName("status")
+    val status: String,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: StockList
+)
+
+@Serializable
+data class StockList(
+    @SerialName("stockList")
+    val asset: List<StockInfo>
+)
+
+@Serializable
+data class StockInfo(
+    @SerialName("accountName")
+    val accountName: String,
+    @SerialName("stockName")
+    val stockName: String,
+    @SerialName("ticker")
+    val ticker: String,
+    @SerialName("quantity")
+    val quantity: String,
+    @SerialName("totalPrice")
+    val totalPrice: String,
+    @SerialName("profit")
+    val profit: String,
+)

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/StockHoldingScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/StockHoldingScreen.kt
@@ -1,0 +1,250 @@
+package com.moneymate.moneymate.ui.asset.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.data.dto.asset.response.StockInfo
+import com.moneymate.moneymate.ui.asset.AssetViewModel
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+import java.text.NumberFormat
+import java.util.Locale
+import kotlin.math.abs
+
+@Composable
+fun StockHoldingScreen(
+    modifier: Modifier = Modifier,
+    viewModel: AssetViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState)
+            .background(MoneyMateTheme.colors.white)
+            .padding(horizontal = 20.dp, vertical = 16.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .padding(bottom = 24.dp)
+                .fillMaxWidth()
+        ) {
+            Box(
+                modifier = Modifier.weight(1f),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_mypage_arrow),
+                    contentDescription = "뒤로가기",
+                    modifier = Modifier
+                        .rotate(180f)
+                        .clickable { onNavigateBack() }
+                )
+            }
+            Box(
+                modifier = Modifier.weight(2f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "보유 주식 목록",
+                    color = MoneyMateTheme.colors.darkGray,
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
+                        fontSize = 20.sp
+                    )
+                )
+            }
+            Box(modifier = Modifier.weight(1f))
+        }
+
+//        stockItemContainer("테슬라","TSL", "2", "130000",  "30")
+//        stockItemContainer("테슬라","TSL", "2", "70000",  "-30")
+
+        stockCompanyContainer(
+            accountName = "키움증권",
+            stockList = listOf(
+                StockInfo("키움증권","테슬라","TSL", "2", "130000",  "30"),
+                StockInfo("키움증권","테슬라","TSL", "2", "130000",  "30"),)
+        )
+        stockCompanyContainer(
+            accountName = "삼성증권",
+            stockList = listOf(
+                StockInfo("삼성증권","테슬라","TSL", "2", "70000",  "-30"),
+                StockInfo("삼성증권","테슬라","TSL", "2", "70000",  "-30"),)
+        )
+
+    }
+}
+
+@Composable
+fun stockItemContainer(
+    //image : Int,
+    stockName : String,
+    ticker : String,
+    quantity : String,
+    totalPrice : String,
+    profitRate : String,
+){
+    val profitAmount = (totalPrice.toDouble() * (1 - 1 / (1 + profitRate.toDouble() / 100)))
+    var priceColor = MoneyMateTheme.colors.black
+    var profitSign = "."
+
+    if (profitAmount.toDouble() > 0) {
+        priceColor = MoneyMateTheme.colors.stockRed
+        profitSign = "+"
+    } else {
+        priceColor = MoneyMateTheme.colors.stockBlue
+        profitSign = "-"
+    }
+
+    Row (
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(81.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ){
+        Row (
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                modifier = Modifier.size(45.dp),
+                painter = painterResource(R.drawable.img_dummy_asset),
+                contentDescription = "asset icon",
+                tint = MoneyMateTheme.colors.lightGray
+            )
+            Spacer(modifier = Modifier.width(20.dp))
+
+            Column (
+                modifier = Modifier
+                    .fillMaxHeight(),
+                verticalArrangement = Arrangement.Center
+            ){
+                Text(
+                    text = stockName+"("+ticker+")",
+                    color = MoneyMateTheme.colors.black,
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(R.font.pretendard_bold)),
+                        fontSize = 14.sp
+                    )
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = quantity+"주",
+                    color = MoneyMateTheme.colors.black,
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(R.font.pretendard_medium)),
+                        fontSize = 12.sp
+                    )
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxHeight(),
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = NumberFormat.getNumberInstance(Locale.US).format(totalPrice.toInt())+"원",
+                color = MoneyMateTheme.colors.black,
+                style = TextStyle(
+                    fontFamily = FontFamily(Font(R.font.pretendard_bold)),
+                    fontSize = 14.sp
+                )
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+
+            Row {
+                Text(
+                    text = profitSign+" "+NumberFormat.getNumberInstance(Locale.US).format(abs(profitAmount))+"원 ",
+                    color = priceColor,
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(R.font.pretendard_bold)),
+                        fontSize = 12.sp
+                    )
+                )
+                Text (
+                    text = "("+profitRate+" %)",
+                    color = priceColor,
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(R.font.pretendard_bold)),
+                        fontSize = 12.sp
+                    )
+                )
+            }
+
+
+        }
+    }
+
+}
+
+@Composable
+fun stockCompanyContainer(
+    accountName: String,
+    stockList: List<StockInfo>,
+){
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 30.dp)
+    ) {
+        Text (
+            text = accountName,
+            color = MoneyMateTheme.colors.darkGray,
+            style = TextStyle(
+                fontFamily = FontFamily(Font(R.font.pretendard_bold)),
+                fontSize = 18.sp
+            )
+        )
+        Spacer (modifier = Modifier.height(8.dp))
+        Spacer (
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(MoneyMateTheme.colors.deepBlue)
+        )
+    }
+    stockList.forEach { item ->
+        stockItemContainer(
+            stockName = item.stockName,
+            ticker = item.ticker,
+            quantity = item.quantity,
+            totalPrice = item.totalPrice,
+            profitRate = item.profit
+        )
+    }
+
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/ManageScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/ManageScreen.kt
@@ -37,6 +37,7 @@ import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 fun ManageScreen(
     modifier: Modifier = Modifier,
     onRetireClick : () -> Unit,
+    onSpendingStatisticsClick : () -> Unit,
     viewModel: ManageViewModel = hiltViewModel()
 ) {
     Column(
@@ -50,5 +51,6 @@ fun ManageScreen(
         MoneyMateMenuButton("노후 설계 시뮬레이션", 67, onRetireClick)
         MoneyMateMenuButton("또래 자산 통계 조회하기", 67, onRetireClick) /*나중에 함수 바꾸기*/
         MoneyMateMenuButton("자산 변동 통계 조회하기", 67, onRetireClick)
+        MoneyMateMenuButton("소비 통계 조회하기", 67, onSpendingStatisticsClick)
     }
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/RetireInputScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/RetireInputScreen.kt
@@ -146,7 +146,7 @@ fun RetireInputScreen(
         Text(
             text = "노후 자금 설계 시뮬레이션입니다.\n아래 입력되어 있는 기본값들을 수정할 수 있습니다.",
             color = Color.Gray,
-            modifier = Modifier.padding(bottom = 24.dp, start = 21.dp),
+            modifier = Modifier.padding(bottom = 24.dp),
             style = TextStyle(
                 fontFamily = FontFamily(Font(R.font.pretendard_regular)),
                 fontSize = 16.sp

--- a/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/SpendingStatisticsScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/SpendingStatisticsScreen.kt
@@ -1,0 +1,92 @@
+package com.moneymate.moneymate.ui.manage.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.ui.manage.ManageViewModel
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@Composable
+fun SpendingStatisticsScreen(
+    modifier: Modifier,
+    viewModel: ManageViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit,
+){
+
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState)
+            .background(MoneyMateTheme.colors.white)
+            .padding(horizontal = 20.dp, vertical = 16.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .padding(bottom = 24.dp)
+                .fillMaxWidth()
+        ) {
+            Box(
+                modifier = Modifier.weight(1f),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_mypage_arrow),
+                    contentDescription = "뒤로가기",
+                    modifier = Modifier
+                        .rotate(180f)
+                        .clickable { onNavigateBack() }
+                )
+            }
+            Box(
+                modifier = Modifier.weight(2f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "소비 통계",
+                    color = MoneyMateTheme.colors.darkGray,
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
+                        fontSize = 20.sp
+                    )
+                )
+            }
+            Box(modifier = Modifier.weight(1f))
+        }
+
+        Text(
+            text = "소비 통계 조회입니다.\n원하는 옵션을 선택해서 소비 현황을 조회해보세요.",
+            color = Color.Gray,
+            modifier = Modifier.padding(bottom = 24.dp),
+            style = TextStyle(
+                fontFamily = FontFamily(Font(R.font.pretendard_regular)),
+                fontSize = 16.sp
+            )
+        )
+
+    }
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
@@ -16,6 +16,7 @@ import com.moneymate.moneymate.ui.finance.screen.NewsArticleScreen
 import com.moneymate.moneymate.ui.finance.screen.NewsPublisherHomeScreen
 import com.moneymate.moneymate.ui.finance.screen.NewsScreen
 import com.moneymate.moneymate.ui.manage.screen.ManageScreen
+import com.moneymate.moneymate.ui.manage.screen.SpendingStatisticsScreen
 import com.moneymate.moneymate.ui.mypage.screen.MyPageScreen
 import kotlinx.serialization.json.Json
 import java.net.URLDecoder
@@ -152,10 +153,25 @@ fun MoneyMateNavGraph(
                 modifier = modifier,
                 onRetireClick = {
                     navController.navigate(Route.RetireGraph.route)
+                },
+                onSpendingStatisticsClick = {
+                    navController.navigate(Route.SpendingStatistics.route)
                 }
             )
         }
         retireNavGraph(navController, modifier)
+        //소비통계 조회 화면
+        composable(
+            route = Route.SpendingStatistics.route
+        ) {
+            SpendingStatisticsScreen(
+                modifier = modifier,
+                onNavigateBack = {
+                    navController.navigateUp()
+                }
+            )
+
+        }
 
         /* 마이페이지 */
         composable(route = Route.MyPage.route) {

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
@@ -9,6 +9,7 @@ import com.moneymate.moneymate.data.dto.account.response.AccountInfo
 import com.moneymate.moneymate.ui.asset.screen.AddAccountScreen
 import com.moneymate.moneymate.ui.asset.screen.AddAssetScreen
 import com.moneymate.moneymate.ui.asset.screen.HomeScreen
+import com.moneymate.moneymate.ui.asset.screen.StockHoldingScreen
 import com.moneymate.moneymate.ui.asset.screen.TransactionHistoryScreen
 import com.moneymate.moneymate.ui.finance.screen.FinanceScreen
 import com.moneymate.moneymate.ui.finance.screen.NewsArticleScreen

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
@@ -14,6 +14,7 @@ sealed class Route(val route: String){
     object AddAccount: Route(route = "home/addAccount")
     object AddAsset: Route(route = "home/addAsset")
     object TransactionHistory: Route(route = "home/transactionHistory")
+    object StockHolding : Route(route = "home/stockHolding")
 
     // 금융 정보
     object Finance: Route(route = "finance")

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
@@ -27,6 +27,7 @@ sealed class Route(val route: String){
     object RetireGraph : Route(route = "retire_graph")
     object RetireInput : Route(route = "myPage/retireInput")
     object RetireResult : Route(route = "myPage/retireResult")
+    object SpendingStatistics : Route(route = "myPage/spendingStatistics")
 
     // 마이페이지
     object MyPage: Route(route = "myPage")

--- a/app/src/main/java/com/moneymate/moneymate/ui/theme/Color.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/theme/Color.kt
@@ -16,6 +16,9 @@ val Neutral500 = Color(0xFFA4A4A6)
 
 val DeepBlue = Color(0xFF0E0857)
 
+val stockRed = Color(0xFFFF0000)
+val stockBlue = Color(0xFF0022FF)
+
 @Immutable
 data class MoneyMateColors(
     val white: Color,
@@ -27,6 +30,8 @@ data class MoneyMateColors(
     val neutral300: Color,
     val neutral500: Color,
     val deepBlue: Color,
+    val stockRed : Color,
+    val stockBlue : Color,
 )
 
 val defaultMoneyMateColors = MoneyMateColors(
@@ -39,6 +44,8 @@ val defaultMoneyMateColors = MoneyMateColors(
     neutral300 = Neutral300,
     neutral500 = Neutral500,
     deepBlue = DeepBlue,
+    stockRed = stockRed,
+    stockBlue = stockBlue
 )
 
 val LocalMoneyMateColorsProvider = staticCompositionLocalOf { defaultMoneyMateColors }


### PR DESCRIPTION
## 🚀 이슈번호


## ✏️ 변경사항
- 보유 주식 조회 화면 ui 구성
- 소비 통계 화면 생성
- 소비 통계 화면 nav 연결

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/e1d773d7-dcd9-449d-8043-31e32ae406b7)


## ✍️ 사용법


## 🎸 기타
