### PR TITLE
[Refactor, Feat] 홈 화면 레이아웃 리팩토링, api 수정

### DIFF
--- a/app/src/main/java/com/moneymate/moneymate/data/dto/asset/request/AssetRegisterRequest.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/asset/request/AssetRegisterRequest.kt
@@ -7,8 +7,6 @@ import kotlinx.serialization.Serializable
 data class AssetRegisterRequest(
     @SerialName("assetName")
     val name: String,
-    @SerialName("assetType")
-    val type: String,
     @SerialName("assetPrice")
     val price: Long
 )

--- a/app/src/main/java/com/moneymate/moneymate/data/dto/asset/response/AssetListResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/asset/response/AssetListResponse.kt
@@ -25,8 +25,6 @@ data class AssetInfo(
     val uid: String,
     @SerialName("assetName")
     val name: String,
-    @SerialName("assetType")
-    val type: String,
     @SerialName("assetPrice")
     val price: Long
 )

--- a/app/src/main/java/com/moneymate/moneymate/data/dto/asset/response/StockListResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/asset/response/StockListResponse.kt
@@ -10,13 +10,7 @@ data class StockListResponse(
     @SerialName("message")
     val message: String,
     @SerialName("data")
-    val data: StockList
-)
-
-@Serializable
-data class StockList(
-    @SerialName("stockList")
-    val asset: List<StockInfo>
+    val data: List<StockInfo>
 )
 
 @Serializable

--- a/app/src/main/java/com/moneymate/moneymate/data/repository/AssetRepository.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/repository/AssetRepository.kt
@@ -42,4 +42,7 @@ class AssetRepository(
             )
         )
     }
+
+    // 주식 조회
+    suspend fun getStockList() = runCatching { assetService.getStockList() }
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/repository/AssetRepository.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/repository/AssetRepository.kt
@@ -31,13 +31,11 @@ class AssetRepository(
     // 자산 등록
     suspend fun registerAsset(
         name: String,
-        type: String,
         price: Long
     ) = runCatching {
         assetService.registerAsset(
             AssetRegisterRequest(
                 name = name,
-                type = type,
                 price = price,
             )
         )

--- a/app/src/main/java/com/moneymate/moneymate/data/service/AssetService.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/service/AssetService.kt
@@ -6,6 +6,7 @@ import com.moneymate.moneymate.data.dto.asset.response.AssetListResponse
 import com.moneymate.moneymate.data.dto.account.response.TransactionHistoryResponse
 import com.moneymate.moneymate.data.dto.asset.request.AssetRegisterRequest
 import com.moneymate.moneymate.data.dto.asset.response.AssetRegisterResponse
+import com.moneymate.moneymate.data.dto.asset.response.StockListResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -30,4 +31,8 @@ interface AssetService {
     suspend fun registerAsset(
         @Body request: AssetRegisterRequest
     ): AssetRegisterResponse
+
+    // 주식 조회
+    @GET("asset/stock")
+    suspend fun getStockList(): StockListResponse
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/AssetViewModel.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/AssetViewModel.kt
@@ -86,13 +86,11 @@ class AssetViewModel @Inject constructor(
     // 자산 등록
     fun registerAsset(
         name: String,
-        type: String,
         price: Long
     ){
         viewModelScope.launch {
             assetRepository.registerAsset(
                 name = name,
-                type = type,
                 price = price
             ).onSuccess { response ->
                 Log.d("AssetViewModel", response.message)

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/AssetViewModel.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/AssetViewModel.kt
@@ -34,7 +34,7 @@ class AssetViewModel @Inject constructor(
     init {
         getTotalAccountList()
         getAssetList()
-//        getStockList()
+        getStockList()
     }
 
     // 전체 계좌 정보 조회
@@ -75,7 +75,7 @@ class AssetViewModel @Inject constructor(
             assetRepository.getAssetList()
                 .onSuccess { response ->
                     _totalAssets.value = response.data.asset
-                    Log.d("AssetViewModel", response.data.asset.toString())
+                    Log.d("AssetViewModel", "자산 조회 성공: ${response.data.asset}")
                 }
                 .onFailure { response ->
                     response.message?.let { Log.d("AssetViewModel", "자산 조회 실패") }
@@ -107,8 +107,8 @@ class AssetViewModel @Inject constructor(
         viewModelScope.launch {
             assetRepository.getStockList()
                 .onSuccess { response ->
-                    _totalStocks.value = response.data.asset
-                    Log.d("AssetViewModel", response.data.asset.toString())
+                    _totalStocks.value = response.data
+                    Log.d("AssetViewModel", response.data.toString())
                 }
                 .onFailure { response ->
                     response.message?.let { Log.d("AssetViewModel", "주식 조회 실패") }

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/AssetViewModel.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/AssetViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.moneymate.moneymate.data.dto.account.response.AccountInfo
 import com.moneymate.moneymate.data.dto.asset.response.AssetInfo
 import com.moneymate.moneymate.data.dto.account.response.TransactionInfo
+import com.moneymate.moneymate.data.dto.asset.response.StockInfo
 import com.moneymate.moneymate.data.repository.AssetRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +24,9 @@ class AssetViewModel @Inject constructor(
     // 홈 화면에서 조회할 전체 자산 정보
     private val _totalAssets= MutableStateFlow<List<AssetInfo>>(emptyList())
     val totalAssets = _totalAssets.asStateFlow()
+    // 홈 화면에서 조회할 전체 주식 정보
+    private val _totalStocks = MutableStateFlow<List<StockInfo>>(emptyList())
+    val totalStocks = _totalStocks.asStateFlow()
     // 계좌 거래 내역 정보
     private val _transactionInfoHistory = MutableStateFlow<List<TransactionInfo>>(emptyList())
     val transactionHistory = _transactionInfoHistory.asStateFlow()
@@ -30,6 +34,7 @@ class AssetViewModel @Inject constructor(
     init {
         getTotalAccountList()
         getAssetList()
+//        getStockList()
     }
 
     // 전체 계좌 정보 조회
@@ -95,6 +100,19 @@ class AssetViewModel @Inject constructor(
             }.onFailure { response ->
                 response.message?.let { Log.d("AssetViewModel", it) }
             }
+        }
+    }
+
+    fun getStockList(){
+        viewModelScope.launch {
+            assetRepository.getStockList()
+                .onSuccess { response ->
+                    _totalStocks.value = response.data.asset
+                    Log.d("AssetViewModel", response.data.asset.toString())
+                }
+                .onFailure { response ->
+                    response.message?.let { Log.d("AssetViewModel", "주식 조회 실패") }
+                }
         }
     }
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/component/AssetContainer.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/component/AssetContainer.kt
@@ -86,7 +86,6 @@ fun AssetContainer(
             for(asset in assetList) {
                 AssetItem(
                     uId = 1,
-                    type = asset.type,
                     name = asset.name,
                     value = asset.price
                 )
@@ -113,8 +112,7 @@ private fun AssetContainerPreview() {
                 AssetInfo(
                     uid = "1",
                     name = "반포자이",
-                    type = "부동산",
-                    price = 40000000
+                    price = 4000000000
                 )
             ),
             onAddClick = {}

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/component/AssetItem.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/component/AssetItem.kt
@@ -23,7 +23,6 @@ import com.moneymate.moneymate.util.toDecimalFormat
 fun AssetItem(
     modifier: Modifier = Modifier,
     uId: Int,
-    type: String,
     name: String,
     value: Long
 ) {
@@ -48,7 +47,7 @@ fun AssetItem(
             ) {
                 Text(text = name, style = MoneyMateTheme.typography.body_02_R_12)
                 Text(
-                    text =if (type == "부동산")  (value/10000).toDecimalFormat() + "만원" else value.toDecimalFormat()+"원",
+                    text = value.toDecimalFormat()+"원",
                     style = MoneyMateTheme.typography.head_02_B_20
                 )
             }
@@ -62,13 +61,11 @@ private fun AssetItemPreview() {
     Column {
         AssetItem(
             uId = 1,
-            type = "부동산",
             name = "반포 자이",
             value = 4250000000
         )
         AssetItem(
             uId = 2,
-            type = "투자",
             name = "엔비디아",
             value = 100000
         )

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/component/StockContainer.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/component/StockContainer.kt
@@ -1,0 +1,115 @@
+package com.moneymate.moneymate.ui.asset.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.data.dto.asset.response.StockInfo
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+
+@Composable
+fun StockContainer(
+    modifier: Modifier = Modifier,
+    stockList : List<StockInfo>,
+    onNavigateToStockDetail : () -> Unit
+) {
+    Column(
+        modifier = modifier.fillMaxWidth()
+            .clip(RoundedCornerShape(20.dp))
+            .background(MoneyMateTheme.colors.white)
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 30.dp)
+        ) {
+            Spacer(modifier = Modifier.size(22.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "주식",
+                    style = MoneyMateTheme.typography.head_02_B_20
+                )
+                Box(
+                    modifier = Modifier
+                        .size(30.dp)
+                        .clickable {
+                            onNavigateToStockDetail()
+                        }
+                ) {
+                    Icon(
+                        modifier = Modifier
+                            .rotate(180f)
+                            .align(Alignment.Center),
+                        painter = painterResource(R.drawable.ic_back),
+                        contentDescription = "arrow",
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.size(22.dp))
+            HorizontalDivider(
+                modifier = Modifier.fillMaxWidth(),
+                thickness = 1.dp,
+                color = MoneyMateTheme.colors.deepBlue
+            )
+        }
+        if (stockList.isNotEmpty()){
+            for(stock in stockList) {
+                StockItem(
+                    stockName = stock.stockName,
+                    ticker = stock.ticker,
+                    stockValue = stock.totalPrice,
+                    profitRate = stock.profit
+                )
+            }
+        } else {
+            Spacer(modifier = Modifier.size(28.dp))
+            Text(
+                text = "등록된 자산이 없습니다.",
+                style = MoneyMateTheme.typography.head_03_SB_16
+            )
+            Spacer(modifier = Modifier.size(28.dp))
+        }
+
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun StockContainerPreview() {
+    val stockList = listOf(
+        StockInfo("키움증권", "테슬라", "TSL", "2", "130000", "30"),
+        StockInfo("삼성증권", "애플", "AAPL", "5", "150000", "-20")
+    )
+    StockContainer(
+        stockList = stockList,
+        onNavigateToStockDetail = {}
+    )
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/component/StockItem.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/component/StockItem.kt
@@ -1,0 +1,82 @@
+package com.moneymate.moneymate.ui.asset.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.data.dto.asset.response.StockInfo
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+import com.moneymate.moneymate.util.toDecimalFormat
+
+@Composable
+fun StockItem(
+    modifier: Modifier = Modifier,
+    stockName: String,
+    ticker: String,
+    stockValue: String,
+    profitRate: String
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 18.dp, horizontal = 35.dp)
+    ) {
+        Row(
+            modifier = Modifier,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                modifier = Modifier.size(45.dp),
+                painter = painterResource(R.drawable.img_dummy_asset),
+                contentDescription = "asset icon",
+                tint = MoneyMateTheme.colors.lightGray
+            )
+            Spacer(modifier = Modifier.size(17.dp))
+            Column(
+                modifier = Modifier,
+            ) {
+                Text(text = stockName+"(${ticker})", style = MoneyMateTheme.typography.body_02_R_12)
+                Text(
+                    text = stockValue.toDouble().toLong().toDecimalFormat()+"원",
+                    style = MoneyMateTheme.typography.head_02_B_20
+                )
+            }
+        }
+        Text(
+            modifier = Modifier
+                .align(Alignment.CenterEnd),
+            text = if(profitRate.startsWith("-")) "$profitRate%" else "+$profitRate%",
+            style = MoneyMateTheme.typography.body_03_M_20,
+            color = when {
+                profitRate.toDouble() == 0.0 -> MoneyMateTheme.colors.black
+                profitRate.startsWith("-") -> MoneyMateTheme.colors.stockBlue
+                else -> MoneyMateTheme.colors.stockRed
+            }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun StockItemPreview() {
+    StockItem(
+        modifier = Modifier,
+        stockName = "테슬라",
+        ticker = "TSLA",
+        stockValue = "1000000.0",
+        profitRate = "5.0"
+    )
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/AddAssetScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/AddAssetScreen.kt
@@ -35,7 +35,6 @@ import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 @Composable
 fun AddAssetScreen(
     modifier: Modifier = Modifier,
-    assetType: String,
     onNavigateBack: () -> Unit,
     viewModel: AssetViewModel = hiltViewModel()
 ) {
@@ -62,7 +61,7 @@ fun AddAssetScreen(
                         )
                         Text(
                             modifier = Modifier.align(Alignment.Center),
-                            text = "$assetType 정보 등록",
+                            text = "투자 자산 정보 등록",
                             style = MoneyMateTheme.typography.head_02_B_20
                         )
                     }
@@ -79,7 +78,7 @@ fun AddAssetScreen(
             ) {
                 Spacer(modifier = Modifier.size(12.dp))
                 Text(
-                    text = "사용자가 보유한 $assetType 정보를 등록합니다.\n${assetType}의 가치와 이름을 입력해주세요.",
+                    text = "사용자가 보유한 투자 자산 정보를 등록합니다.\n투자 자산의 가치와 이름을 입력해주세요.",
                     style = MoneyMateTheme.typography.head_03_R_16
                 )
                 // 은행명
@@ -97,7 +96,7 @@ fun AddAssetScreen(
                     },
                     placeholder = {
                         Text(
-                            text = "등록할 ${assetType}의 이름을 입력해주세요.",
+                            text = "등록할 투자 자산의 이름을 입력해주세요.",
                             style = MoneyMateTheme.typography.body_01_M_14
                         )
                     }
@@ -117,7 +116,7 @@ fun AddAssetScreen(
                     },
                     placeholder = {
                         Text(
-                            text = "등록할 ${assetType}의 가치를 입력해주세요.",
+                            text = "등록할 투자 자산의 가치를 입력해주세요.",
                             style = MoneyMateTheme.typography.body_01_M_14
                         )
                     }
@@ -133,10 +132,8 @@ fun AddAssetScreen(
             contentColor = MoneyMateTheme.colors.white,
             text = "등록"
         ) {
-            val type = if(assetType == "부동산") "부동산" else "투자"
             viewModel.registerAsset(
                 name = assetName,
-                type = type,
                 price = assetValue.toLong()
             )
             onNavigateBack()
@@ -149,7 +146,6 @@ fun AddAssetScreen(
 private fun AddAssetScreenPreview() {
     AddAssetScreen(
         modifier = Modifier,
-        assetType = "부동산",
         onNavigateBack = {},
     )
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
@@ -16,9 +16,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.moneymate.moneymate.data.dto.account.response.AccountInfo
+import com.moneymate.moneymate.data.dto.asset.response.StockInfo
 import com.moneymate.moneymate.ui.asset.AssetViewModel
 import com.moneymate.moneymate.ui.asset.component.AccountContainer
 import com.moneymate.moneymate.ui.asset.component.AssetContainer
+import com.moneymate.moneymate.ui.asset.component.StockContainer
 import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 
 @Composable
@@ -26,6 +28,7 @@ fun HomeScreen(
     modifier: Modifier = Modifier,
     onAddAccountClick: (String) -> Unit,
     onAddAssetClick: (String) -> Unit,
+    onStockClick: () -> Unit,
     onAccountItemClick: (AccountInfo) -> Unit,
     viewModel: AssetViewModel = hiltViewModel()
 ) {
@@ -33,6 +36,8 @@ fun HomeScreen(
     // 전체 계좌
     val totalAccounts = viewModel.totalAccounts.collectAsStateWithLifecycle().value
     val totalAssets = viewModel.totalAssets.collectAsStateWithLifecycle().value
+    // 전체 주식
+    val totalStocks = viewModel.totalStocks.collectAsStateWithLifecycle().value
 
     LaunchedEffect(Unit) {
         viewModel.getAssetList()
@@ -89,22 +94,23 @@ fun HomeScreen(
             }
         )
         Spacer(modifier = Modifier.size(30.dp))
-        //부동산
-        AssetContainer(
-            name = "부동산",
-            assetList = realEstateList,
-            onAddClick = {
-                onAddAssetClick("부동산")
-            }
-        )
-        Spacer(modifier = Modifier.size(30.dp))
         // 투자
         AssetContainer(
             name = "투자 자산",
-            assetList = investmentList,
+            assetList = totalAssets,
             onAddClick = {
                 onAddAssetClick("투자 자산")
             }
+        )
+        Spacer(modifier = Modifier.size(30.dp))
+        // 주식
+        StockContainer(
+//            stockList = totalStocks,
+            stockList = listOf(
+                StockInfo("키움증권", "테슬라", "TSL", "2", "130000", "30"),
+                StockInfo("삼성증권", "애플", "AAPL", "5", "150000", "-20")
+            ),
+            onNavigateToStockDetail = onStockClick
         )
         Spacer(modifier = Modifier.size(30.dp))
     }
@@ -116,6 +122,7 @@ private fun HomeScreenPreview() {
     HomeScreen(
         onAddAccountClick = {},
         onAddAssetClick = {},
-        onAccountItemClick = {}
+        onAccountItemClick = {},
+        onStockClick = {}
     )
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/HomeScreen.kt
@@ -35,6 +35,7 @@ fun HomeScreen(
     val scrollState = rememberScrollState()
     // 전체 계좌
     val totalAccounts = viewModel.totalAccounts.collectAsStateWithLifecycle().value
+    // 전체 자산
     val totalAssets = viewModel.totalAssets.collectAsStateWithLifecycle().value
     // 전체 주식
     val totalStocks = viewModel.totalStocks.collectAsStateWithLifecycle().value
@@ -48,9 +49,6 @@ fun HomeScreen(
     val depositList = totalAccounts.filter { it.type == "입출금" }
     val savingsList = totalAccounts.filter { it.type == "예적금" }
     val securitiesList = totalAccounts.filter { it.type == "증권" }
-    // 자산별 리스트
-    val realEstateList = totalAssets.filter { it.type == "부동산" }
-    val investmentList = totalAssets.filter { it.type == "투자" }
 
     Column(modifier = modifier.fillMaxSize()
         .background(MoneyMateTheme.colors.backgroundWhite)
@@ -105,11 +103,7 @@ fun HomeScreen(
         Spacer(modifier = Modifier.size(30.dp))
         // 주식
         StockContainer(
-//            stockList = totalStocks,
-            stockList = listOf(
-                StockInfo("키움증권", "테슬라", "TSL", "2", "130000", "30"),
-                StockInfo("삼성증권", "애플", "AAPL", "5", "150000", "-20")
-            ),
+            stockList = totalStocks,
             onNavigateToStockDetail = onStockClick
         )
         Spacer(modifier = Modifier.size(30.dp))

--- a/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/StockHoldingScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/asset/screen/StockHoldingScreen.kt
@@ -16,8 +16,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,6 +32,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.moneymate.moneymate.R
 import com.moneymate.moneymate.data.dto.asset.response.StockInfo
 import com.moneymate.moneymate.ui.asset.AssetViewModel
@@ -37,6 +41,7 @@ import java.text.NumberFormat
 import java.util.Locale
 import kotlin.math.abs
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StockHoldingScreen(
     modifier: Modifier = Modifier,
@@ -44,76 +49,61 @@ fun StockHoldingScreen(
     onNavigateBack: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
+    val stockList = viewModel.totalStocks.collectAsStateWithLifecycle()
 
     Column(
         modifier = modifier
             .fillMaxSize()
-            .verticalScroll(scrollState)
             .background(MoneyMateTheme.colors.white)
-            .padding(horizontal = 20.dp, vertical = 16.dp)
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .padding(bottom = 24.dp)
-                .fillMaxWidth()
-        ) {
-            Box(
-                modifier = Modifier.weight(1f),
-                contentAlignment = Alignment.CenterStart
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_mypage_arrow),
-                    contentDescription = "뒤로가기",
-                    modifier = Modifier
-                        .rotate(180f)
-                        .clickable { onNavigateBack() }
-                )
-            }
-            Box(
-                modifier = Modifier.weight(2f),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = "보유 주식 목록",
-                    color = MoneyMateTheme.colors.darkGray,
-                    style = TextStyle(
-                        fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
-                        fontSize = 20.sp
+        TopAppBar(
+            modifier = Modifier,
+            title = {
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    Icon(
+                        modifier = Modifier
+                            .clickable { onNavigateBack() },
+                        painter = painterResource(id = R.drawable.ic_back),
+                        contentDescription = "back icon"
                     )
-                )
-            }
-            Box(modifier = Modifier.weight(1f))
+                    Text(
+                        modifier = Modifier.align(Alignment.Center),
+                        text = "보유 주식 목록",
+                        style = MoneyMateTheme.typography.head_02_B_20
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MoneyMateTheme.colors.white
+            )
+        )
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 30.dp)
+                .verticalScroll(scrollState)
+        ) {
+            // accountName을 기준으로 stockList를 그룹화하여 각 증권사별로 StockCompanyContainer 생성
+            stockList.value
+                .groupBy { it.accountName }
+                .forEach { (accountName, stocks) ->
+                    StockCompanyContainer(
+                        accountName = accountName,
+                        stockList = stocks
+                    )
+                }
         }
-
-//        stockItemContainer("테슬라","TSL", "2", "130000",  "30")
-//        stockItemContainer("테슬라","TSL", "2", "70000",  "-30")
-
-        stockCompanyContainer(
-            accountName = "키움증권",
-            stockList = listOf(
-                StockInfo("키움증권","테슬라","TSL", "2", "130000",  "30"),
-                StockInfo("키움증권","테슬라","TSL", "2", "130000",  "30"),)
-        )
-        stockCompanyContainer(
-            accountName = "삼성증권",
-            stockList = listOf(
-                StockInfo("삼성증권","테슬라","TSL", "2", "70000",  "-30"),
-                StockInfo("삼성증권","테슬라","TSL", "2", "70000",  "-30"),)
-        )
-
     }
 }
 
 @Composable
-fun stockItemContainer(
+fun StockItemContainer(
     //image : Int,
-    stockName : String,
-    ticker : String,
-    quantity : String,
-    totalPrice : String,
-    profitRate : String,
-){
+    stockName: String,
+    ticker: String,
+    quantity: String,
+    totalPrice: String,
+    profitRate: String,
+) {
     val profitAmount = (totalPrice.toDouble() * (1 - 1 / (1 + profitRate.toDouble() / 100)))
     var priceColor = MoneyMateTheme.colors.black
     var profitSign = "."
@@ -126,14 +116,14 @@ fun stockItemContainer(
         profitSign = "-"
     }
 
-    Row (
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(81.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
-    ){
-        Row (
+    ) {
+        Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
@@ -144,13 +134,13 @@ fun stockItemContainer(
             )
             Spacer(modifier = Modifier.width(20.dp))
 
-            Column (
+            Column(
                 modifier = Modifier
                     .fillMaxHeight(),
                 verticalArrangement = Arrangement.Center
-            ){
+            ) {
                 Text(
-                    text = stockName+"("+ticker+")",
+                    text = "$stockName($ticker)",
                     color = MoneyMateTheme.colors.black,
                     style = TextStyle(
                         fontFamily = FontFamily(Font(R.font.pretendard_bold)),
@@ -159,7 +149,7 @@ fun stockItemContainer(
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = quantity+"주",
+                    text = quantity + "주",
                     color = MoneyMateTheme.colors.black,
                     style = TextStyle(
                         fontFamily = FontFamily(Font(R.font.pretendard_medium)),
@@ -176,7 +166,8 @@ fun stockItemContainer(
             verticalArrangement = Arrangement.Center
         ) {
             Text(
-                text = NumberFormat.getNumberInstance(Locale.US).format(totalPrice.toInt())+"원",
+                text = NumberFormat.getNumberInstance(Locale.US)
+                    .format(totalPrice.toDouble().toLong()) + "원",
                 color = MoneyMateTheme.colors.black,
                 style = TextStyle(
                     fontFamily = FontFamily(Font(R.font.pretendard_bold)),
@@ -187,15 +178,16 @@ fun stockItemContainer(
 
             Row {
                 Text(
-                    text = profitSign+" "+NumberFormat.getNumberInstance(Locale.US).format(abs(profitAmount))+"원 ",
+                    text = profitSign + " " + NumberFormat.getNumberInstance(Locale.US)
+                        .format(abs(profitAmount)) + "원 ",
                     color = priceColor,
                     style = TextStyle(
                         fontFamily = FontFamily(Font(R.font.pretendard_bold)),
                         fontSize = 12.sp
                     )
                 )
-                Text (
-                    text = "("+profitRate+" %)",
+                Text(
+                    text = "($profitRate %)",
                     color = priceColor,
                     style = TextStyle(
                         fontFamily = FontFamily(Font(R.font.pretendard_bold)),
@@ -211,17 +203,17 @@ fun stockItemContainer(
 }
 
 @Composable
-fun stockCompanyContainer(
+fun StockCompanyContainer(
     accountName: String,
     stockList: List<StockInfo>,
-){
+) {
 
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 30.dp)
     ) {
-        Text (
+        Text(
             text = accountName,
             color = MoneyMateTheme.colors.darkGray,
             style = TextStyle(
@@ -229,8 +221,8 @@ fun stockCompanyContainer(
                 fontSize = 18.sp
             )
         )
-        Spacer (modifier = Modifier.height(8.dp))
-        Spacer (
+        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(1.dp)
@@ -238,7 +230,7 @@ fun stockCompanyContainer(
         )
     }
     stockList.forEach { item ->
-        stockItemContainer(
+        StockItemContainer(
             stockName = item.stockName,
             ticker = item.ticker,
             quantity = item.quantity,

--- a/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/AssetStatissticsScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/AssetStatissticsScreen.kt
@@ -1,0 +1,308 @@
+package com.moneymate.moneymate.ui.manage.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moneymate.moneymate.R
+import com.moneymate.moneymate.ui.theme.MoneyMateTheme
+import java.time.LocalDate
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AssetStatisticsScreen(
+    modifier: Modifier = Modifier,
+    onNavigateBack: () -> Unit,
+) {
+    var currentMonth by rememberSaveable { mutableStateOf(LocalDate.now()) }
+    var selectedDuration by rememberSaveable { mutableIntStateOf(1) }
+    var selectedAssetType by rememberSaveable { mutableStateOf("전체") }
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+    ) {
+        TopAppBar(
+            modifier = Modifier,
+            title = {
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    Icon(
+                        modifier = Modifier
+                            .clickable { onNavigateBack() },
+                        painter = painterResource(id = R.drawable.ic_back),
+                        contentDescription = "back icon"
+                    )
+                    Text(
+                        modifier = Modifier.align(Alignment.Center),
+                        text = "자산 변동 통계",
+                        style = MoneyMateTheme.typography.head_02_B_20
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MoneyMateTheme.colors.white
+            )
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 20.dp)
+                .background(MoneyMateTheme.colors.white)
+        ) {
+            Spacer(modifier = Modifier.size(12.dp))
+            Text(
+                text = "자산 변동 통계 조회입니다.\n원하는 옵션을 선택해서 결과를 조회해보세요.",
+                style = MoneyMateTheme.typography.head_03_R_16
+            )
+            // 조회기간, 자산 종류
+            Spacer(modifier = Modifier.size(20.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "조회 기간",
+                    style = MoneyMateTheme.typography.head_03_SB_16
+                )
+                Spacer(modifier = Modifier.size(10.dp))
+                Row(
+                    modifier = Modifier,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Button(
+                        modifier = Modifier
+                            .border(
+                                width = 2.dp,
+                                color = MoneyMateTheme.colors.deepBlue,
+                                shape = RoundedCornerShape(25.dp)
+                            )
+                            .size(width = 72.dp, height = 42.dp),
+                        shape = RoundedCornerShape(25.dp),
+                        contentPadding = PaddingValues(0.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (selectedDuration == 1) MoneyMateTheme.colors.deepBlue else MoneyMateTheme.colors.white,
+                            contentColor = if (selectedDuration == 1) MoneyMateTheme.colors.white else MoneyMateTheme.colors.deepBlue
+                        ),
+                        onClick = { selectedDuration = 1 },
+                    ) {
+                        Text(text = "1년")
+                    }
+                    Button(
+                        modifier = Modifier
+                            .border(
+                                width = 2.dp,
+                                color = MoneyMateTheme.colors.deepBlue,
+                                shape = RoundedCornerShape(25.dp)
+                            )
+                            .size(width = 72.dp, height = 42.dp),
+                        shape = RoundedCornerShape(25.dp),
+                        contentPadding = PaddingValues(0.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (selectedDuration == 5) MoneyMateTheme.colors.deepBlue else MoneyMateTheme.colors.white,
+                            contentColor = if (selectedDuration == 5) MoneyMateTheme.colors.white else MoneyMateTheme.colors.deepBlue
+                        ),
+                        onClick = { selectedDuration = 5 },
+                    ) {
+                        Text(text = "5년")
+                    }
+                    Button(
+                        modifier = Modifier
+                            .border(
+                                width = 2.dp,
+                                color = MoneyMateTheme.colors.deepBlue,
+                                shape = RoundedCornerShape(25.dp)
+                            )
+                            .size(width = 72.dp, height = 42.dp),
+                        shape = RoundedCornerShape(25.dp),
+                        contentPadding = PaddingValues(0.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (selectedDuration == 10) MoneyMateTheme.colors.deepBlue else MoneyMateTheme.colors.white,
+                            contentColor = if (selectedDuration == 10) MoneyMateTheme.colors.white else MoneyMateTheme.colors.deepBlue
+                        ),
+                        onClick = { selectedDuration = 10 },
+                    ) {
+                        Text(text = "10년")
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.size(10.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "자산 종류",
+                    style = MoneyMateTheme.typography.head_03_SB_16
+                )
+                Spacer(modifier = Modifier.size(10.dp))
+                Row(
+                    modifier = Modifier
+                        .horizontalScroll(scrollState),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Button(
+                        modifier = Modifier
+                            .border(
+                                width = 2.dp,
+                                color = MoneyMateTheme.colors.deepBlue,
+                                shape = RoundedCornerShape(25.dp)
+                            )
+                            .size(width = 72.dp, height = 42.dp),
+                        shape = RoundedCornerShape(25.dp),
+                        contentPadding = PaddingValues(0.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (selectedAssetType == "전체") MoneyMateTheme.colors.deepBlue else MoneyMateTheme.colors.white,
+                            contentColor = if (selectedAssetType == "전체") MoneyMateTheme.colors.white else MoneyMateTheme.colors.deepBlue
+                        ),
+                        onClick = { selectedAssetType = "전체" },
+                    ) {
+                        Text(text = "전체")
+                    }
+                    Button(
+                        modifier = Modifier
+                            .border(
+                                width = 2.dp,
+                                color = MoneyMateTheme.colors.deepBlue,
+                                shape = RoundedCornerShape(25.dp)
+                            )
+                            .size(width = 72.dp, height = 42.dp),
+                        shape = RoundedCornerShape(25.dp),
+                        contentPadding = PaddingValues(0.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (selectedAssetType == "입출금") MoneyMateTheme.colors.deepBlue else MoneyMateTheme.colors.white,
+                            contentColor = if (selectedAssetType == "입출금") MoneyMateTheme.colors.white else MoneyMateTheme.colors.deepBlue
+                        ),
+                        onClick = { selectedAssetType = "입출금" },
+                    ) {
+                        Text(text = "입출금")
+                    }
+                    Button(
+                        modifier = Modifier
+                            .border(
+                                width = 2.dp,
+                                color = MoneyMateTheme.colors.deepBlue,
+                                shape = RoundedCornerShape(25.dp)
+                            )
+                            .size(width = 72.dp, height = 42.dp),
+                        shape = RoundedCornerShape(25.dp),
+                        contentPadding = PaddingValues(0.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (selectedAssetType == "적금") MoneyMateTheme.colors.deepBlue else MoneyMateTheme.colors.white,
+                            contentColor = if (selectedAssetType == "적금") MoneyMateTheme.colors.white else MoneyMateTheme.colors.deepBlue
+                        ),
+                        onClick = { selectedAssetType = "적금" },
+                    ) {
+                        Text(text = "적금")
+                    }
+                    Button(
+                        modifier = Modifier
+                            .border(
+                                width = 2.dp,
+                                color = MoneyMateTheme.colors.deepBlue,
+                                shape = RoundedCornerShape(25.dp)
+                            )
+                            .size(width = 72.dp, height = 42.dp),
+                        shape = RoundedCornerShape(25.dp),
+                        contentPadding = PaddingValues(0.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (selectedAssetType == "증권") MoneyMateTheme.colors.deepBlue else MoneyMateTheme.colors.white,
+                            contentColor = if (selectedAssetType == "증권") MoneyMateTheme.colors.white else MoneyMateTheme.colors.deepBlue
+                        ),
+                        onClick = { selectedAssetType = "증권" },
+                    ) {
+                        Text(text = "증권")
+                    }
+                }
+            }
+
+            // 월 표시
+            Spacer(modifier = Modifier.size(20.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_back),
+                    contentDescription = "previous month",
+                    modifier = Modifier.clickable {
+                        currentMonth = currentMonth.minusMonths(1)
+                    }
+                )
+                Text(
+                    text = when (selectedDuration) {
+                        1 -> "${currentMonth.year}년"
+                        5 -> "${currentMonth.minusMonths(60).year}년 ${
+                            currentMonth.minusMonths(
+                                60
+                            ).monthValue
+                        }월 ~ ${currentMonth.year}년 ${currentMonth.monthValue}월"
+                        10 -> "${currentMonth.minusMonths(120).year}년 ${
+                            currentMonth.minusMonths(
+                                120
+                            ).monthValue
+                        }월 ~ ${currentMonth.year}년 ${currentMonth.monthValue}월"
+                        else -> "${currentMonth.year}년"
+                    },
+                    style = MoneyMateTheme.typography.head_03_SB_16
+                )
+                Icon(
+                    painter = painterResource(R.drawable.ic_back),
+                    contentDescription = "next month",
+                    modifier = Modifier
+                        .rotate(180f)
+                        .clickable {
+                            currentMonth = currentMonth.plusMonths(1)
+                        }
+                )
+            }
+            Spacer(modifier = Modifier.size(20.dp))
+            // TODO: 변동 그래프
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AssetStatisticsScreenPreview() {
+    AssetStatisticsScreen() {
+
+    }
+}

--- a/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/ManageScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/manage/screen/ManageScreen.kt
@@ -37,6 +37,7 @@ import com.moneymate.moneymate.ui.theme.MoneyMateTheme
 fun ManageScreen(
     modifier: Modifier = Modifier,
     onRetireClick : () -> Unit,
+    onAssetStatisticsClick: () -> Unit,
     onSpendingStatisticsClick : () -> Unit,
     viewModel: ManageViewModel = hiltViewModel()
 ) {
@@ -50,7 +51,7 @@ fun ManageScreen(
     ) {
         MoneyMateMenuButton("노후 설계 시뮬레이션", 67, onRetireClick)
         MoneyMateMenuButton("또래 자산 통계 조회하기", 67, onRetireClick) /*나중에 함수 바꾸기*/
-        MoneyMateMenuButton("자산 변동 통계 조회하기", 67, onRetireClick)
+        MoneyMateMenuButton("자산 변동 통계 조회하기", 67, onAssetStatisticsClick)
         MoneyMateMenuButton("소비 통계 조회하기", 67, onSpendingStatisticsClick)
     }
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
@@ -43,7 +43,7 @@ fun MoneyMateNavGraph(
                     navController.navigate("${Route.AddAccount.route}/$accountType")
                 },
                 onAddAssetClick = { assetType ->
-                    navController.navigate("${Route.AddAsset.route}/$assetType")
+                    navController.navigate(Route.AddAsset.route)
                 },
                 onStockClick = {
                     navController.navigate(Route.StockHolding.route)
@@ -68,13 +68,9 @@ fun MoneyMateNavGraph(
             )
         }
         // 자산 추가 화면
-        composable(
-            route = "${Route.AddAsset.route}/{assetType}",
-        ) { backStackEntry ->
-            val assetType = backStackEntry.arguments?.getString("assetType") ?: ""
+        composable(route = Route.AddAsset.route,) {
             AddAssetScreen(
                 modifier = modifier,
-                assetType = assetType,
                 onNavigateBack = {
                     navController.navigateUp()
                 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
@@ -15,6 +15,7 @@ import com.moneymate.moneymate.ui.finance.screen.FinanceScreen
 import com.moneymate.moneymate.ui.finance.screen.NewsArticleScreen
 import com.moneymate.moneymate.ui.finance.screen.NewsPublisherHomeScreen
 import com.moneymate.moneymate.ui.finance.screen.NewsScreen
+import com.moneymate.moneymate.ui.manage.screen.AssetStatisticsScreen
 import com.moneymate.moneymate.ui.manage.screen.ManageScreen
 import com.moneymate.moneymate.ui.manage.screen.SpendingStatisticsScreen
 import com.moneymate.moneymate.ui.mypage.screen.MyPageScreen
@@ -165,6 +166,9 @@ fun MoneyMateNavGraph(
                 onRetireClick = {
                     navController.navigate(Route.RetireGraph.route)
                 },
+                onAssetStatisticsClick = {
+                    navController.navigate(Route.AssetStatistics.route)
+                },
                 onSpendingStatisticsClick = {
                     navController.navigate(Route.SpendingStatistics.route)
                 }
@@ -182,6 +186,15 @@ fun MoneyMateNavGraph(
                 }
             )
 
+        }
+        // 자산 변동 통계 조회 화면
+        composable(route = Route.AssetStatistics.route){
+            AssetStatisticsScreen(
+                modifier = modifier,
+                onNavigateBack = {
+                    navController.navigateUp()
+                }
+            )
         }
 
         /* 마이페이지 */

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/MoneyMateNavGraph.kt
@@ -44,6 +44,9 @@ fun MoneyMateNavGraph(
                 onAddAssetClick = { assetType ->
                     navController.navigate("${Route.AddAsset.route}/$assetType")
                 },
+                onStockClick = {
+                    navController.navigate(Route.StockHolding.route)
+                },
                 onAccountItemClick = { accountInfo ->
                     val accountInfoJson = Json.encodeToString(accountInfo)
                     navController.navigate("${Route.TransactionHistory.route}/$accountInfoJson")
@@ -85,6 +88,14 @@ fun MoneyMateNavGraph(
             TransactionHistoryScreen(
                 modifier = modifier,
                 accountInfo = accountInfo,
+                onNavigateBack = {
+                    navController.navigateUp()
+                }
+            )
+        }
+        composable(route = Route.StockHolding.route){
+            StockHoldingScreen(
+                modifier = modifier,
                 onNavigateBack = {
                     navController.navigateUp()
                 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/navigation/Route.kt
@@ -27,6 +27,7 @@ sealed class Route(val route: String){
     object RetireGraph : Route(route = "retire_graph")
     object RetireInput : Route(route = "myPage/retireInput")
     object RetireResult : Route(route = "myPage/retireResult")
+    object AssetStatistics : Route(route = "myPage/assetStatistics")
     object SpendingStatistics : Route(route = "myPage/spendingStatistics")
 
     // 마이페이지


### PR DESCRIPTION
## 🚀 이슈번호


## ✏️ 변경사항
- 기존 부동산/투자자산 항목 -> 투자자산/주식으로 리팩토링
- assetType에 따른 AddAssetScreen으로의 네비게이션 리팩토링
- 홈 화면에서의 주식 조회 로직, 보유 주식 조회 화면 로직 구현
- 보유 주식 조회 화면에서 상단바 재사용하도록 레이아웃 리팩토링
-  자산 변동 통계 화면에서의 조회기간/자산 종류 선택 버튼 구현 및 기본 레이아웃 작성


## 📷 스크린샷

https://github.com/user-attachments/assets/580a675e-5114-4bb7-9688-fd53ca4d7074


## ✍️ 사용법


## 🎸 기타
