### PR TITLE
[UI] 소비통계 도넛차트 색상 변경

### DIFF
--- a/app/src/main/java/com/moneymate/moneymate/ui/manage/component/SpendingStatisticsChart.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/manage/component/SpendingStatisticsChart.kt
@@ -49,11 +49,10 @@ fun SpendingStatisticChart(
 
 private val donutColors = listOf(
     Color(0xFF0E0857),
-    Color(0xFF1C1970),
-    Color(0xFF2A2D89),
-    Color(0xFF3B44A2),
-    Color(0xFF5561BB),
-    Color(0xFF7582D4),
-    Color(0xFF9DA9ED),
+    Color(0xFF003885),
+    Color(0xFF0062A4),
+    Color(0xFF008BB5),
+    Color(0xFF00B3BC),
+    Color(0xFF61DAC1),
     Color(0xFFF5F5F5),
 )

--- a/app/src/main/java/com/moneymate/moneymate/ui/manage/component/SpendingStatisticsItem.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/manage/component/SpendingStatisticsItem.kt
@@ -35,7 +35,7 @@ fun SpendingStatisticsItem(
     var rankIndex = categoryRank
     val expenseText = String.format(Locale.KOREA, "%,d원", expense)
 
-    if (categoryRank > 7) { rankIndex = 7 }
+    if (categoryRank > donutColors.size - 1) { rankIndex = donutColors.size-1 }
     Row (
         modifier = Modifier
             .fillMaxWidth()
@@ -83,11 +83,10 @@ fun SpendingStatisticsItem(
 
 private val donutColors = listOf(
     Color(0xFF0E0857),
-    Color(0xFF1C1970),
-    Color(0xFF2A2D89),
-    Color(0xFF3B44A2),
-    Color(0xFF5561BB),
-    Color(0xFF7582D4),
-    Color(0xFF9DA9ED),
+    Color(0xFF003885),
+    Color(0xFF0062A4),
+    Color(0xFF008BB5),
+    Color(0xFF00B3BC),
+    Color(0xFF61DAC1),
     Color(0xFFF5F5F5),
 )


### PR DESCRIPTION
## 🚀 이슈번호


## ✏️ 변경사항
- 소비통계 도넛차트 색상 변경

## 📷 스크린샷
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/dec78e48-ee7b-4537-8ac3-16dc455ccfd8" />


## ✍️ 사용법


## 🎸 기타
