### PR TITLE
[FIX]: 시장 가격 조회시 하한가에 해당하는 속성 추가

### DIFF
--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/MarketIndexComponent.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/MarketIndexComponent.kt
@@ -129,7 +129,7 @@ fun MarketIndexItem(
                 style = MoneyMateTheme.typography.head_04_SB_14,
                 color = when (status) {
                     "RISING", "UPPER_LIMIT" -> MoneyMateTheme.colors.stockRed
-                    "FALLING" -> MoneyMateTheme.colors.stockBlue
+                    "FALLING", "LOWER_LIMIT" -> MoneyMateTheme.colors.stockBlue
                     else -> MoneyMateTheme.colors.darkGray
                 }
             )

--- a/app/src/main/java/com/moneymate/moneymate/ui/finance/component/StockMarketComponent.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/finance/component/StockMarketComponent.kt
@@ -169,7 +169,7 @@ fun StockMarketItem(
                 style = MoneyMateTheme.typography.head_04_SB_14,
                 color = when (status) {
                     "RISING", "UPPER_LIMIT" -> MoneyMateTheme.colors.stockRed
-                    "FALLING" -> MoneyMateTheme.colors.stockBlue
+                    "FALLING", "LOWER_LIMIT" -> MoneyMateTheme.colors.stockBlue
                     else -> MoneyMateTheme.colors.darkGray
                 }
             )


### PR DESCRIPTION
## 🚀 이슈번호


## ✏️ 변경사항
- 증시 조회에서 가격에 색상이 적용되지 않는 문제를 발견해서 누락된 속성 추가

## 📷 스크린샷


## ✍️ 사용법


## 🎸 기타
