### PR TITLE
[FIX]: 해외 증시 정보 dto 변경 해결

### DIFF
--- a/app/src/main/java/com/moneymate/moneymate/data/dto/finance/response/market/ForeignStockResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/finance/response/market/ForeignStockResponse.kt
@@ -36,7 +36,7 @@ data class ForeignStockDto(
     val accumulatedTradingValueKrwHangeul: String? = null, // 누적 거래대금(원)
     val localTradedAt: String? = null,
     val marketStatus: String? = null,
-    val overMarketPriceInfo: String? = null,
+    val overMarketPriceInfo: OverMarketPriceInfoDto? = null,
     val marketValue: String? = null,
     val marketValueHangeul: String? = null,
     val marketValueKrwHangeul: String? = null,
@@ -94,4 +94,16 @@ data class TradeStopTypeDto(
     val code: String,
     val text: String,
     val name: String
+)
+
+@Serializable
+data class OverMarketPriceInfoDto(
+    val tradingSessionType: String,
+    val overMarketStatus: String,
+    val overPrice: String,
+    val compareToPreviousPrice: CompareToPreviousPriceDto,
+    val compareToPreviousClosePrice: String,
+    val fluctuationsRatio: String,
+    val localTradedAt: String,
+    val tradeStopType: TradeStopTypeDto? = null
 )


### PR DESCRIPTION
## 🚀 이슈번호


## ✏️ 변경사항
- 해외증시 api 응답 형식 변경으로 인해 ui에 정보가 반영 안되는 문제 해결

## 📷 스크린샷


## ✍️ 사용법


## 🎸 기타
