### PR TITLE
[REFACTOR] markdown 라이브러리 수정 및 가독성 개선

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -94,8 +94,9 @@ dependencies {
     implementation("com.github.fracassi-marco:JetChart:1.4.3")
     // splash
     implementation(libs.splash)
-    // markdown
-    implementation(libs.markdowntext)
+    // richtext markdown
+    implementation(libs.richtext.ui)
+    implementation(libs.richtext.commonmark)
     // Coil for image loading (SVG support)
     implementation(libs.coil.compose)
     implementation(libs.coil.svg)

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/component/NewsSummaryItem.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/component/NewsSummaryItem.kt
@@ -33,8 +33,14 @@ fun NewsSummaryItem(
             .fillMaxWidth()
     ) {
         Text(
-            text = title,
+            text = when(title) {
+                "stock" -> "증시 뉴스 요약"
+                "realestate" -> "부동산 뉴스 요약"
+                "economy" -> "경제 뉴스 요약"
+                else -> "뉴스 요약"
+            },
             style = MoneyMateTheme.typography.head_01_B_24
+                .copy(color = MoneyMateTheme.colors.deepBlue)
         )
         HorizontalDivider(
             modifier = Modifier

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/component/NewsSummaryItem.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/component/NewsSummaryItem.kt
@@ -47,7 +47,32 @@ fun NewsSummaryItem(
             LocalTextStyle provides MoneyMateTheme.typography.insightArticleStyle
         ) {
             Material3RichText(
-                modifier = Modifier.padding(horizontal = 4.dp),
+                style = RichTextStyle(
+                    headingStyle = { level, textStyle ->
+                        when (level) {
+                            0 -> textStyle.copy( // H1
+                                fontSize = 24.sp,
+                                lineHeight = 32.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                            1 -> textStyle.copy( // H2
+                                fontSize = 20.sp,
+                                lineHeight = 28.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                            2 -> textStyle.copy( // H3
+                                fontSize = 18.sp,
+                                lineHeight = 24.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                            else -> textStyle.copy(
+                                fontSize = 16.sp,
+                                lineHeight = 20.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                )
             ) {
                 Markdown(content = content)
             }

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/component/NewsSummaryItem.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/component/NewsSummaryItem.kt
@@ -7,13 +7,19 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.halilibo.richtext.markdown.Markdown
+import com.halilibo.richtext.ui.RichTextStyle
+import com.halilibo.richtext.ui.material3.Material3RichText
 import com.moneymate.moneymate.ui.theme.MoneyMateTheme
-import dev.jeziellago.compose.markdowntext.MarkdownText
 
 @Composable
 fun NewsSummaryItem(
@@ -25,7 +31,6 @@ fun NewsSummaryItem(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-
     ) {
         Text(
             text = title,
@@ -38,11 +43,15 @@ fun NewsSummaryItem(
             thickness = 1.dp,
             color = MoneyMateTheme.colors.deepBlue
         )
-        MarkdownText(
-            modifier = Modifier.padding(horizontal = 4.dp),
-            markdown = content,
-            style = MoneyMateTheme.typography.body_01_R_16
-        )
+        CompositionLocalProvider(
+            LocalTextStyle provides MoneyMateTheme.typography.insightArticleStyle
+        ) {
+            Material3RichText(
+                modifier = Modifier.padding(horizontal = 4.dp),
+            ) {
+                Markdown(content = content)
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/moneymate/moneymate/ui/theme/Type.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/theme/Type.kt
@@ -28,7 +28,7 @@ data class MoneyMateTypography(
     val body_01_M_14: TextStyle,
     val body_01_M_16: TextStyle,
     val body_01_R_14: TextStyle,
-    val body_01_R_16: TextStyle,
+    val insightArticleStyle: TextStyle,
     val body_02_SB_12: TextStyle,
     val body_02_R_12: TextStyle,
     val body_03_M_20: TextStyle,
@@ -91,10 +91,10 @@ val defaultMoneyMateTypography = MoneyMateTypography(
         fontSize = 14.sp,
         lineHeight = 14.sp
     ),
-    body_01_R_16 = TextStyle(
+    insightArticleStyle = TextStyle(
         fontFamily = moneyMateFontRegular,
         fontSize = 16.sp,
-        lineHeight = 16.sp
+        lineHeight = 24.sp
     ),
     body_02_SB_12 = TextStyle(
         fontFamily = moneyMateFontSemiBold,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ datastorePreferences = "1.2.0-alpha02"
 vico="2.1.3"
 splash="1.0.1"
 markdowntext = "0.5.7"
+richtext = "0.17.0"
 coil = "2.7.0"
 
 
@@ -59,7 +60,8 @@ vico-compose = { group = "com.patrykandpatrick.vico", name = "compose", version.
 vico-compose-m2 = { group = "com.patrykandpatrick.vico", name = "compose-m2", version.ref = "vico" }
 vico-compose-m3 = { group = "com.patrykandpatrick.vico", name = "compose-m3", version.ref = "vico" }
 splash = { group = "androidx.core", name = "core-splashscreen", version.ref = "splash" }
-markdowntext = { group = "com.github.jeziellago", name = "compose-markdown", version.ref = "markdowntext" }
+richtext-ui = { group = "com.halilibo.compose-richtext", name = "richtext-ui-material3", version.ref = "richtext" }
+richtext-commonmark = { group = "com.halilibo.compose-richtext", name = "richtext-commonmark", version.ref = "richtext" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 coil-svg = { group = "io.coil-kt", name = "coil-svg", version.ref = "coil" }
 


### PR DESCRIPTION
## 🚀 이슈번호


## ✏️ 변경사항
- 기존의 markdown 라이브러리가 볼드체가 포함된 nested bullet을 제대로 처리하지 못하여 다른 라이브러리로의 마이그레이션 진행
- 각 뉴스 요약 항목의 제목 스타일 수정
- markdown을 렌더링 할 때, 가독성 향상을 위해 텍스트 스타일별 폰트 지정

## 📷 스크린샷

https://github.com/user-attachments/assets/8b1f7a52-3652-42a8-a625-3052454abb4b

## ✍️ 사용법
- https://github.com/halilozercan/compose-richtext?tab=readme-ov-file

## 🎸 기타
