### PR TITLE
[REFACTOR] 뉴스 요약 화면 드롭다운, 요약일자 추가

### DIFF
--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/component/NewsSummaryItem.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/component/NewsSummaryItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -34,6 +35,11 @@ fun NewsSummaryItem(
     generatedTime: String
 ) {
     val scrollState = rememberScrollState()
+
+    // title이 변경될 때마다 스크롤을 맨 위로 리셋
+    LaunchedEffect(title) {
+        scrollState.scrollTo(0)
+    }
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/component/NewsSummaryItem.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/component/NewsSummaryItem.kt
@@ -1,16 +1,21 @@
 package com.moneymate.moneymate.ui.insight.component
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,20 +33,33 @@ fun NewsSummaryItem(
     content: String,
     generatedTime: String
 ) {
+    val scrollState = rememberScrollState()
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
     ) {
-        Text(
-            text = when(title) {
-                "stock" -> "증시 뉴스 요약"
-                "realestate" -> "부동산 뉴스 요약"
-                "economy" -> "경제 뉴스 요약"
-                else -> "뉴스 요약"
-            },
-            style = MoneyMateTheme.typography.head_01_B_24
-                .copy(color = MoneyMateTheme.colors.deepBlue)
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = when (title) {
+                    "stock" -> "증시 뉴스 요약"
+                    "realestate" -> "부동산 뉴스 요약"
+                    "economy" -> "경제 뉴스 요약"
+                    else -> "증시 뉴스 요약"
+                },
+                style = MoneyMateTheme.typography.head_01_B_24
+                    .copy(color = MoneyMateTheme.colors.deepBlue)
+            )
+            Text(
+                text = generatedTime.substringBefore("T"),
+                style = MoneyMateTheme.typography.body_01_M_14
+                    .copy(color = MoneyMateTheme.colors.lightGray)
+            )
+        }
         HorizontalDivider(
             modifier = Modifier
                 .fillMaxWidth()
@@ -49,39 +67,48 @@ fun NewsSummaryItem(
             thickness = 1.dp,
             color = MoneyMateTheme.colors.deepBlue
         )
-        CompositionLocalProvider(
-            LocalTextStyle provides MoneyMateTheme.typography.insightArticleStyle
+        Column(
+            modifier = Modifier
+                .verticalScroll(scrollState)
         ) {
-            Material3RichText(
-                style = RichTextStyle(
-                    headingStyle = { level, textStyle ->
-                        when (level) {
-                            0 -> textStyle.copy( // H1
-                                fontSize = 24.sp,
-                                lineHeight = 32.sp,
-                                fontWeight = FontWeight.Bold
-                            )
-                            1 -> textStyle.copy( // H2
-                                fontSize = 20.sp,
-                                lineHeight = 28.sp,
-                                fontWeight = FontWeight.Bold
-                            )
-                            2 -> textStyle.copy( // H3
-                                fontSize = 18.sp,
-                                lineHeight = 24.sp,
-                                fontWeight = FontWeight.Bold
-                            )
-                            else -> textStyle.copy(
-                                fontSize = 16.sp,
-                                lineHeight = 20.sp,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-                    }
-                )
+            CompositionLocalProvider(
+                LocalTextStyle provides MoneyMateTheme.typography.insightArticleStyle
             ) {
-                Markdown(content = content)
+                Material3RichText(
+                    style = RichTextStyle(
+                        headingStyle = { level, textStyle ->
+                            when (level) {
+                                0 -> textStyle.copy( // H1
+                                    fontSize = 24.sp,
+                                    lineHeight = 32.sp,
+                                    fontWeight = FontWeight.Bold
+                                )
+
+                                1 -> textStyle.copy( // H2
+                                    fontSize = 20.sp,
+                                    lineHeight = 28.sp,
+                                    fontWeight = FontWeight.Bold
+                                )
+
+                                2 -> textStyle.copy( // H3
+                                    fontSize = 18.sp,
+                                    lineHeight = 24.sp,
+                                    fontWeight = FontWeight.Bold
+                                )
+
+                                else -> textStyle.copy(
+                                    fontSize = 16.sp,
+                                    lineHeight = 20.sp,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
+                        }
+                    )
+                ) {
+                    Markdown(content = content)
+                }
             }
+            Spacer(modifier = Modifier.size(20.dp))
         }
     }
 }
@@ -119,7 +146,7 @@ private fun NewsSummaryItemPreview() {
             modifier = Modifier,
             title = "제목",
             content = "서울 일부 비규제지역(성동, 마포, 분당, 과천 등)을 중심으로 정부의 추가 규제 발표 전 '막차'를 타려는 매수 심리가 확산하며 집값이 급등하고 매물이 감소하고 있다.\n\n이에 정부는 과열 양상을 보이는 지역을 규제지역으로 추가 지정하고, 주택담보대출 한도 축소 및 DSR 규제 강화 등을 포함한 추가 부동산 대책 발표를 예고했다. 다만, 강력한 대출 규제가 매매 수요를 전세 시장으로 이동시켜 전셋값 상승을 부추길 수 있다는 우려도 제기된다.\n\n실제로 서울은 대출 규제, 집주인의 실거주 증가, 기존 세입자의 계약 갱신 등으로 전세 매물 부족 현상이 심화되고 있다. 이는 전셋값 급등과 월세화 가속으로 이어지고 있다.\n\n공급 측면에서는 서울 잠원동 일대 소규모 단지들이 관리처분인가를 받는 등 정비사업이 속도를 내고 있으나, 높은 공사비로 인한 조합원 분담금 부담이 과제로 남아있다. 서울시는 신속통합기획을 통해 은마아파트 등 주요 단지의 재건축을 지원하며 공급 확대를 꾀하고 있다. 반면 지방은 신규 아파트 공급이 급감했다.\n\n이외에 수도권에 집중된 집값 담합 시도에 대한 당국의 조사가 진행 중이며, 부동산 정책을 둘러싼 정치권의 책임 공방과 아파트 단지 간 갈등도 나타나고 있다.",
-            generatedTime = ""
+            generatedTime = "2025.11.11"
         )
     }
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/NewsInsightScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/NewsInsightScreen.kt
@@ -4,22 +4,33 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -36,6 +47,18 @@ fun NewsInsightScreen(
     viewModel: NewsInsightViewModel = hiltViewModel()
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+    var dropdownExpanded by remember { mutableStateOf(false) }
+    val dropdownList = listOf("증시", "부동산", "경제")
+    var selectedDropdownMenu by rememberSaveable { mutableStateOf(dropdownList[0]) }
+
+    // 선택된 카테고리에 해당하는 뉴스 아이템 찾기
+    val selectedCategory = when (selectedDropdownMenu) {
+        "증시" -> "stock"
+        "부동산" -> "realestate"
+        "경제" -> "economy"
+        else -> "stock"
+    }
+    val selectedNewsItem = uiState.value.newsList.find { it.category == selectedCategory }
 
     Column(
         modifier = Modifier
@@ -63,12 +86,55 @@ fun NewsInsightScreen(
                 containerColor = MoneyMateTheme.colors.white
             )
         )
+        // 드롭다운 메뉴
+        Box(
+            modifier = Modifier
+                .padding(start = 20.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .clickable { dropdownExpanded = !dropdownExpanded },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = selectedDropdownMenu,
+                    style = MoneyMateTheme.typography.head_03_B_16
+                )
+                Spacer(modifier = Modifier.size(4.dp))
+                Icon(
+                    modifier = Modifier
+                        .rotate(270f),
+                    painter = painterResource(id = R.drawable.ic_back),
+                    contentDescription = "dropdown icon"
+                )
+            }
+            DropdownMenu(
+                modifier = Modifier
+                    .background(color = MoneyMateTheme.colors.backgroundWhite),
+                expanded = dropdownExpanded,
+                offset = DpOffset(0.dp, 0.dp),
+                onDismissRequest = { dropdownExpanded = false }
+            ) {
+                dropdownList.forEachIndexed { index, selectionOption ->
+                    DropdownMenuItem(
+                        modifier = Modifier
+                            .background(color = MoneyMateTheme.colors.backgroundWhite),
+                        text = { Text(text = selectionOption) },
+                        onClick = {
+                            selectedDropdownMenu = dropdownList[index]
+                            dropdownExpanded = false
+                        }
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.size(10.dp))
+        
         Column(
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .padding(horizontal = 20.dp)
         ) {
-
             when (uiState.value.isLoading) {
                 true -> {
                     Box(
@@ -81,18 +147,12 @@ fun NewsInsightScreen(
                 }
 
                 false -> {
-                    LazyColumn {
-                        items(uiState.value.newsList.size) { index ->
-                            val newsItem = uiState.value.newsList[index]
-                            NewsSummaryItem(
-                                title = newsItem.category,
-                                content = newsItem.content,
-                                generatedTime = newsItem.generatedTime
-                            )
-                            if (index < uiState.value.newsList.size - 1) {
-                                Spacer(modifier = Modifier.height(30.dp))
-                            }
-                        }
+                    selectedNewsItem?.let { newsItem ->
+                        NewsSummaryItem(
+                            title = newsItem.category,
+                            content = newsItem.content,
+                            generatedTime = newsItem.generatedTime
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## 🚀 이슈번호


## ✏️ 변경사항
- 기존에 3가지 항목을 한번에 보여주는 방식에서 각 카테고리를 선택해서 조회하도록 수정
- 각 항목별 요약일자 정보를 추가

## 📷 스크린샷

https://github.com/user-attachments/assets/7096a7ac-e002-4b99-8adf-3e9290c4cc00

## ✍️ 사용법


## 🎸 기타
