### PR TITLE
[FEAT] AI 포트폴리오 분석 구현

### DIFF
--- a/app/src/main/java/com/moneymate/moneymate/data/dto/insight/response/PortfolioInsightResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/insight/response/PortfolioInsightResponse.kt
@@ -11,10 +11,5 @@ data class PortfolioInsightResponse(
     @SerialName("status")
     val status: String,
     @SerialName("data")
-    val data: List<PortfolioInsightData>,
-)
-@Serializable
-data class PortfolioInsightData(
-    @SerialName("text")
-    val text: String
+    val data: String,
 )

--- a/app/src/main/java/com/moneymate/moneymate/data/dto/insight/response/PortfolioInsightResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/insight/response/PortfolioInsightResponse.kt
@@ -1,0 +1,20 @@
+package com.moneymate.moneymate.data.dto.insight.response
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PortfolioInsightResponse(
+    @SerialName("message")
+    val message: String,
+    @SerialName("status")
+    val status: String,
+    @SerialName("data")
+    val data: List<PortfolioInsightData>,
+)
+@Serializable
+data class PortfolioInsightData(
+    @SerialName("text")
+    val text: String
+)

--- a/app/src/main/java/com/moneymate/moneymate/data/repository/FinanceRepository.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/repository/FinanceRepository.kt
@@ -93,4 +93,6 @@ class FinanceRepository(
     }
 
     suspend fun getNewsInsight() = runCatching { financeService.getNewsInsight() }
+
+    suspend fun getPortfolioInsight() = runCatching { financeService.getPortfolioInsight() }
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/repository/FinanceRepository.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/repository/FinanceRepository.kt
@@ -6,11 +6,12 @@ import com.moneymate.moneymate.data.dto.finance.response.DepositProductItemDto
 import com.moneymate.moneymate.data.dto.finance.response.MortgageLoanProductItemDto
 import com.moneymate.moneymate.data.dto.finance.response.RentHouseLoanProductItemDto
 import com.moneymate.moneymate.data.dto.finance.response.SavingProductItemDto
-import com.moneymate.moneymate.data.dto.insight.response.NewsSummaryData
+import com.moneymate.moneymate.data.service.InsightService
 import com.moneymate.moneymate.data.service.FinanceService
 
 class FinanceRepository(
-    private val financeService: FinanceService
+    private val financeService: FinanceService,
+    private val aiInsightService: InsightService
 ) {
     suspend fun getNewsList() : List<NewsInfo> {
         return financeService.getNewsList().data
@@ -92,7 +93,7 @@ class FinanceRepository(
         ).data
     }
 
-    suspend fun getNewsInsight() = runCatching { financeService.getNewsInsight() }
+    suspend fun getNewsInsight() = runCatching { aiInsightService.getNewsInsight() }
 
-    suspend fun getPortfolioInsight() = runCatching { financeService.getPortfolioInsight() }
+    suspend fun getPortfolioInsight() = runCatching { aiInsightService.getPortfolioInsight() }
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/service/FinanceService.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/service/FinanceService.kt
@@ -8,6 +8,7 @@ import com.moneymate.moneymate.data.dto.finance.response.NewsListResponse
 import com.moneymate.moneymate.data.dto.finance.response.RentHouseLoanProductResponse
 import com.moneymate.moneymate.data.dto.finance.response.SavingProductResponse
 import com.moneymate.moneymate.data.dto.insight.response.NewsInsightResponse
+import com.moneymate.moneymate.data.dto.insight.response.PortfolioInsightResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -74,4 +75,7 @@ interface FinanceService {
 
     @GET("news/ai-summary")
     suspend fun getNewsInsight(): NewsInsightResponse
+
+    @GET("portfolio/ai-summary")
+    suspend fun getPortfolioInsight(): PortfolioInsightResponse
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/service/FinanceService.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/service/FinanceService.kt
@@ -7,8 +7,6 @@ import com.moneymate.moneymate.data.dto.finance.response.NewsDetailResponse
 import com.moneymate.moneymate.data.dto.finance.response.NewsListResponse
 import com.moneymate.moneymate.data.dto.finance.response.RentHouseLoanProductResponse
 import com.moneymate.moneymate.data.dto.finance.response.SavingProductResponse
-import com.moneymate.moneymate.data.dto.insight.response.NewsInsightResponse
-import com.moneymate.moneymate.data.dto.insight.response.PortfolioInsightResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -72,10 +70,4 @@ interface FinanceService {
         @Query("crdtLendRateType") crdtLendRateType: String,
         @Query("joinWay") joinWay: String
     ): CreditLoanProductResponse
-
-    @GET("news/ai-summary")
-    suspend fun getNewsInsight(): NewsInsightResponse
-
-    @GET("portfolio/ai-summary")
-    suspend fun getPortfolioInsight(): PortfolioInsightResponse
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/service/InsightService.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/service/InsightService.kt
@@ -1,0 +1,14 @@
+package com.moneymate.moneymate.data.service
+
+import com.moneymate.moneymate.data.dto.insight.response.NewsInsightResponse
+import com.moneymate.moneymate.data.dto.insight.response.PortfolioInsightResponse
+import retrofit2.http.GET
+
+interface InsightService {
+    @GET("news/ai-summary")
+    suspend fun getNewsInsight(): NewsInsightResponse
+
+    @GET("portfolio/ai-summary")
+    suspend fun getPortfolioInsight(): PortfolioInsightResponse
+}
+

--- a/app/src/main/java/com/moneymate/moneymate/di/NetworkModule.kt
+++ b/app/src/main/java/com/moneymate/moneymate/di/NetworkModule.kt
@@ -14,6 +14,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
 import retrofit2.Retrofit
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -59,10 +60,28 @@ object NetworkModule {
     @Singleton
     @DomesticStockOkHttpClient
     fun providesDomesticStockOkHttpClient(
-        loggingInterceptor: HttpLoggingInterceptor
+loggingInterceptor: HttpLoggingInterceptor
     ): OkHttpClient =
         OkHttpClient.Builder().apply {
             addInterceptor(loggingInterceptor)
+        }.build()
+
+    @Provides
+    @Singleton
+    @InsightOkHttpClient
+    fun providesInsightOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor,
+        authInterceptor: AuthInterceptor,
+        tokenAuthenticator: TokenAuthenticator
+    ): OkHttpClient =
+        OkHttpClient.Builder().apply {
+            addInterceptor(loggingInterceptor)
+            addInterceptor(authInterceptor)
+            authenticator(tokenAuthenticator)
+            // AI 요약 요청은 시간이 오래 걸리므로 타임아웃을 60초로 설정
+            connectTimeout(60, TimeUnit.SECONDS)
+            readTimeout(60, TimeUnit.SECONDS)
+            writeTimeout(60, TimeUnit.SECONDS)
         }.build()
 
     @Provides
@@ -98,6 +117,18 @@ object NetworkModule {
         converterFactory: Converter.Factory
     ): Retrofit = Retrofit.Builder()
         .baseUrl(BuildConfig.DOMESTIC_STOCK_BASE_URL)
+        .client(client)
+        .addConverterFactory(converterFactory)
+        .build()
+
+    @Provides
+    @Singleton
+    @InsightRetrofit
+    fun providesInsightRetrofit(
+        @InsightOkHttpClient client: OkHttpClient,
+        converterFactory: Converter.Factory
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BuildConfig.BASE_URL)
         .client(client)
         .addConverterFactory(converterFactory)
         .build()

--- a/app/src/main/java/com/moneymate/moneymate/di/Qualifiers.kt
+++ b/app/src/main/java/com/moneymate/moneymate/di/Qualifiers.kt
@@ -22,3 +22,11 @@ annotation class DomesticStockRetrofit
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class DomesticStockOkHttpClient
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class InsightRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class InsightOkHttpClient

--- a/app/src/main/java/com/moneymate/moneymate/di/RepositoryModule.kt
+++ b/app/src/main/java/com/moneymate/moneymate/di/RepositoryModule.kt
@@ -8,6 +8,7 @@ import com.moneymate.moneymate.data.repository.ForeignStockRepository
 import com.moneymate.moneymate.data.repository.DomesticStockRepository
 import com.moneymate.moneymate.data.repository.MyPageRepository
 import com.moneymate.moneymate.data.repository.StockIconRepository
+import com.moneymate.moneymate.data.service.InsightService
 import com.moneymate.moneymate.data.service.AssetService
 import com.moneymate.moneymate.data.service.AuthService
 import com.moneymate.moneymate.data.service.FinanceService
@@ -38,7 +39,10 @@ object RepositoryModule {
 
     @Provides
     @Singleton
-    fun providesFinanceRepository(financeService: FinanceService): FinanceRepository = FinanceRepository(financeService)
+    fun providesFinanceRepository(
+        financeService: FinanceService,
+        insightService: InsightService
+    ): FinanceRepository = FinanceRepository(financeService, insightService)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/moneymate/moneymate/di/ServiceModule.kt
+++ b/app/src/main/java/com/moneymate/moneymate/di/ServiceModule.kt
@@ -1,5 +1,6 @@
 package com.moneymate.moneymate.di
 
+import com.moneymate.moneymate.data.service.InsightService
 import com.moneymate.moneymate.data.service.AssetService
 import com.moneymate.moneymate.data.service.AuthService
 import com.moneymate.moneymate.data.service.FinanceService
@@ -51,4 +52,9 @@ object ServiceModule {
     @Singleton
     fun providesMyPageService(@DefaultRetrofit retrofit: Retrofit): MyPageService =
         retrofit.create(MyPageService::class.java)
+
+    @Provides
+    @Singleton
+    fun providesInsightService(@InsightRetrofit retrofit: Retrofit): InsightService =
+        retrofit.create(InsightService::class.java)
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/PortfolioInsightViewModel.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/PortfolioInsightViewModel.kt
@@ -1,10 +1,8 @@
 package com.moneymate.moneymate.ui.insight
 
 import android.util.Log
-import androidx.compose.foundation.rememberPlatformOverscrollFactory
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.moneymate.moneymate.data.dto.insight.response.PortfolioInsightData
 import com.moneymate.moneymate.data.repository.FinanceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,7 +14,7 @@ import javax.inject.Inject
 
 data class PortfolioInsightUiState(
     val isLoading: Boolean = false,
-    val insight: List<PortfolioInsightData> = emptyList(),
+    val insight: String = "",
     val errorMessage: String? = null
 )
 

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/PortfolioInsightViewModel.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/PortfolioInsightViewModel.kt
@@ -1,13 +1,50 @@
 package com.moneymate.moneymate.ui.insight
 
+import android.util.Log
+import androidx.compose.foundation.rememberPlatformOverscrollFactory
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.moneymate.moneymate.data.dto.insight.response.PortfolioInsightData
 import com.moneymate.moneymate.data.repository.FinanceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+data class PortfolioInsightUiState(
+    val isLoading: Boolean = false,
+    val insight: List<PortfolioInsightData> = emptyList(),
+    val errorMessage: String? = null
+)
 
 @HiltViewModel
 class PortfolioInsightViewModel@Inject constructor(
     private val repository: FinanceRepository
 ): ViewModel() {
+    private val _uiState = MutableStateFlow(PortfolioInsightUiState())
+    val uiState: StateFlow<PortfolioInsightUiState> = _uiState.asStateFlow()
 
+    init {
+        getPortfolioInsight()
+    }
+
+    fun getPortfolioInsight() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            repository.getPortfolioInsight()
+                .onSuccess { response ->
+                    val insight = response.data
+                    _uiState.update { it.copy(isLoading = false, insight = insight) }
+                    Log.d("PortfolioInsightViewModel", "포트폴리오 분석 조회 성공")
+                }
+                .onFailure { response ->
+                    val errorMessage = response.message ?: "포트폴리오 요약 조회 실패"
+                    _uiState.update { it.copy(isLoading = false, errorMessage = errorMessage) }
+                    Log.d("PortfolioInsightViewModel", "포트폴리오 분석 조회 실패")
+                }
+        }
+    }
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/PortfolioInsightScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/PortfolioInsightScreen.kt
@@ -2,6 +2,7 @@ package com.moneymate.moneymate.ui.insight.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -42,8 +43,6 @@ fun PortfolioInsightScreen(
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
     val scrollState = rememberScrollState()
-    // TODO: 타입 수정하여 uiState에서 가져오도록
-    val content = ""
 
     Column(
         modifier = Modifier
@@ -73,9 +72,10 @@ fun PortfolioInsightScreen(
         )
         Column(
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .padding(horizontal = 20.dp)
-                .verticalScroll(state = scrollState)
+                .verticalScroll(state = scrollState),
+            verticalArrangement = Arrangement.Center
         ) {
 
             when (uiState.value.isLoading) {
@@ -84,7 +84,8 @@ fun PortfolioInsightScreen(
                         modifier = Modifier.fillMaxSize()
                     ) {
                         CircularProgressIndicator(
-                            modifier = Modifier.align(Alignment.Center)
+                            modifier = Modifier.align(Alignment.Center),
+                            color = MoneyMateTheme.colors.deepBlue
                         )
                     }
                 }
@@ -120,7 +121,7 @@ fun PortfolioInsightScreen(
                                 }
                             )
                         ) {
-                            Markdown(content = content)
+                            Markdown(content = uiState.value.insight)
                         }
                     }
                 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/PortfolioInsightScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/PortfolioInsightScreen.kt
@@ -7,17 +7,28 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.halilibo.richtext.markdown.Markdown
+import com.halilibo.richtext.ui.RichTextStyle
+import com.halilibo.richtext.ui.material3.Material3RichText
 import com.moneymate.moneymate.R
 import com.moneymate.moneymate.ui.insight.PortfolioInsightViewModel
 import com.moneymate.moneymate.ui.theme.MoneyMateTheme
@@ -29,6 +40,11 @@ fun PortfolioInsightScreen(
     onNavigateBack: () -> Unit,
     viewModel: PortfolioInsightViewModel = hiltViewModel()
 ) {
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+    val scrollState = rememberScrollState()
+    // TODO: 타입 수정하여 uiState에서 가져오도록
+    val content = ""
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -59,8 +75,56 @@ fun PortfolioInsightScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp)
+                .verticalScroll(state = scrollState)
         ) {
 
+            when (uiState.value.isLoading) {
+                true -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.align(Alignment.Center)
+                        )
+                    }
+                }
+                false -> {
+                    CompositionLocalProvider(
+                        LocalTextStyle provides MoneyMateTheme.typography.insightArticleStyle
+                    ) {
+                        Material3RichText(
+                            style = RichTextStyle(
+                                headingStyle = { level, textStyle ->
+                                    when (level) {
+                                        0 -> textStyle.copy( // H1
+                                            fontSize = 24.sp,
+                                            lineHeight = 32.sp,
+                                            fontWeight = FontWeight.Bold
+                                        )
+                                        1 -> textStyle.copy( // H2
+                                            fontSize = 20.sp,
+                                            lineHeight = 28.sp,
+                                            fontWeight = FontWeight.Bold
+                                        )
+                                        2 -> textStyle.copy( // H3
+                                            fontSize = 18.sp,
+                                            lineHeight = 24.sp,
+                                            fontWeight = FontWeight.Bold
+                                        )
+                                        else -> textStyle.copy(
+                                            fontSize = 16.sp,
+                                            lineHeight = 20.sp,
+                                            fontWeight = FontWeight.Bold
+                                        )
+                                    }
+                                }
+                            )
+                        ) {
+                            Markdown(content = content)
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## 🚀 이슈번호


## ✏️ 변경사항
- 포트폴리오 분석 화면 구현, 데이터 로딩시에 인디케이터 표시하도록 처리
- 포트폴리오 분석 요청시 Timeout이 발생하여 Qualifier를 통해 AI 뉴스 요약, AI 포트폴리오 분석 요청에 사용할 Retrofit, OkhttpClient를 분리

## 📷 스크린샷
<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/31e11789-af4b-44c8-813a-ce4b97db010d" />

<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/72290e17-7e7e-42ec-bef7-3e4f7afb92b7" />

## ✍️ 사용법


## 🎸 기타
