### PR TITLE
[REFACTOR, FEAT] 포트폴리오 분석 결과 캐싱, 요청 횟수 조회 기능 구현

### DIFF
--- a/app/src/main/java/com/moneymate/moneymate/data/dto/insight/response/PortfolioInsightResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/insight/response/PortfolioInsightResponse.kt
@@ -11,5 +11,15 @@ data class PortfolioInsightResponse(
     @SerialName("status")
     val status: String,
     @SerialName("data")
-    val data: String,
+    val data: PortfolioInsightInfo,
+)
+
+@Serializable
+data class PortfolioInsightInfo(
+    @SerialName("userCount")
+    val userCount: Int,
+    @SerialName("context")
+    val context: String,
+    @SerialName("currentTime")
+    val currentTime: String,
 )

--- a/app/src/main/java/com/moneymate/moneymate/data/dto/insight/response/PortfolioUserCountResponse.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/dto/insight/response/PortfolioUserCountResponse.kt
@@ -1,0 +1,24 @@
+package com.moneymate.moneymate.data.dto.insight.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PortfolioUserCountResponse(
+    @SerialName("message")
+    val message: String,
+    @SerialName("status")
+    val status: String,
+    @SerialName("data")
+    val data: UserCountInfo,
+)
+
+@Serializable
+data class UserCountInfo(
+    @SerialName("userCount")
+    val userCount: Int,
+    @SerialName("context")
+    val context: String,
+    @SerialName("currentTime")
+    val currentTime: String,
+)

--- a/app/src/main/java/com/moneymate/moneymate/data/repository/FinanceRepository.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/repository/FinanceRepository.kt
@@ -96,4 +96,6 @@ class FinanceRepository(
     suspend fun getNewsInsight() = runCatching { aiInsightService.getNewsInsight() }
 
     suspend fun getPortfolioInsight() = runCatching { aiInsightService.getPortfolioInsight() }
+
+    suspend fun getPortfolioUserCount() = runCatching { financeService.getPortfolioUserCount() }
 }

--- a/app/src/main/java/com/moneymate/moneymate/data/service/FinanceService.kt
+++ b/app/src/main/java/com/moneymate/moneymate/data/service/FinanceService.kt
@@ -7,6 +7,7 @@ import com.moneymate.moneymate.data.dto.finance.response.NewsDetailResponse
 import com.moneymate.moneymate.data.dto.finance.response.NewsListResponse
 import com.moneymate.moneymate.data.dto.finance.response.RentHouseLoanProductResponse
 import com.moneymate.moneymate.data.dto.finance.response.SavingProductResponse
+import com.moneymate.moneymate.data.dto.insight.response.PortfolioUserCountResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -70,4 +71,7 @@ interface FinanceService {
         @Query("crdtLendRateType") crdtLendRateType: String,
         @Query("joinWay") joinWay: String
     ): CreditLoanProductResponse
+
+    @GET("portfolio/user-count")
+    suspend fun getPortfolioUserCount(): PortfolioUserCountResponse
 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/PortfolioInsightViewModel.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/PortfolioInsightViewModel.kt
@@ -4,38 +4,80 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.moneymate.moneymate.data.repository.FinanceRepository
+import com.moneymate.moneymate.util.insight.InsightCacheManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 data class PortfolioInsightUiState(
     val isLoading: Boolean = false,
     val insight: String = "",
+    val insightDate: String = "",
     val errorMessage: String? = null
 )
 
 @HiltViewModel
 class PortfolioInsightViewModel@Inject constructor(
-    private val repository: FinanceRepository
+    private val repository: FinanceRepository,
+    private val insightCacheManager: InsightCacheManager
 ): ViewModel() {
     private val _uiState = MutableStateFlow(PortfolioInsightUiState())
     val uiState: StateFlow<PortfolioInsightUiState> = _uiState.asStateFlow()
 
     init {
-        getPortfolioInsight()
+        loadCachedInsight()
     }
 
+    /**
+     * 캐시된 인사이트를 먼저 로드합니다.
+     */
+    private fun loadCachedInsight() {
+        viewModelScope.launch {
+            val cachedInsight = insightCacheManager.getPortfolioInsight().first()
+            val cachedTimestamp = insightCacheManager.getPortfolioInsightTimestamp().first()
+            
+            if (cachedInsight != null && cachedTimestamp != null) {
+                _uiState.update {
+                    it.copy(
+                        insight = cachedInsight,
+                        insightDate = cachedTimestamp,
+                        isLoading = false
+                    ) 
+                }
+                Log.d("PortfolioInsightViewModel", "캐시된 포트폴리오 분석 로드 성공")
+            } else {
+                Log.d("PortfolioInsightViewModel", "캐시된 데이터가 없습니다.")
+            }
+        }
+    }
+
+    /**
+     * 새로운 포트폴리오 인사이트를 요청합니다.
+     */
     fun getPortfolioInsight() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             repository.getPortfolioInsight()
                 .onSuccess { response ->
-                    val insight = response.data
-                    _uiState.update { it.copy(isLoading = false, insight = insight) }
+                    val insight = response.data.context
+                    val timestamp = response.data.currentTime.substringBefore("T")
+
+                    // 인사이트를 캐시에 저장
+                    insightCacheManager.savePortfolioInsight(insight, timestamp)
+                    
+                    _uiState.update { 
+                        it.copy(
+                            isLoading = false, 
+                            insight = insight,
+                            insightDate = timestamp
+                        ) 
+                    }
                     Log.d("PortfolioInsightViewModel", "포트폴리오 분석 조회 성공")
                 }
                 .onFailure { response ->

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/PortfolioInsightViewModel.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/PortfolioInsightViewModel.kt
@@ -17,6 +17,7 @@ import javax.inject.Inject
 
 data class PortfolioInsightUiState(
     val isLoading: Boolean = false,
+    val dailyRequest: Int = 3,
     val insight: String = "",
     val insightDate: String = "",
     val errorMessage: String? = null
@@ -31,12 +32,11 @@ class PortfolioInsightViewModel@Inject constructor(
     val uiState: StateFlow<PortfolioInsightUiState> = _uiState.asStateFlow()
 
     init {
+        getDailyRequestCount()
         loadCachedInsight()
     }
 
-    /**
-     * 캐시된 인사이트를 먼저 로드합니다.
-     */
+    // 캐시된 분석을 먼저 로드합니다.
     private fun loadCachedInsight() {
         viewModelScope.launch {
             val cachedInsight = insightCacheManager.getPortfolioInsight().first()
@@ -57,9 +57,7 @@ class PortfolioInsightViewModel@Inject constructor(
         }
     }
 
-    /**
-     * 새로운 포트폴리오 인사이트를 요청합니다.
-     */
+    // 새로운 포트폴리오 분석 요청
     fun getPortfolioInsight() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
@@ -79,11 +77,44 @@ class PortfolioInsightViewModel@Inject constructor(
                         ) 
                     }
                     Log.d("PortfolioInsightViewModel", "포트폴리오 분석 조회 성공")
+                    
+                    // 분석 요청 후 남은 횟수 업데이트
+                    getDailyRequestCount()
                 }
                 .onFailure { response ->
                     val errorMessage = response.message ?: "포트폴리오 요약 조회 실패"
                     _uiState.update { it.copy(isLoading = false, errorMessage = errorMessage) }
                     Log.d("PortfolioInsightViewModel", "포트폴리오 분석 조회 실패")
+                }
+        }
+    }
+
+    // 분석 요청 횟수를 가져옵니다
+    fun getDailyRequestCount() {
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(isLoading = true)
+            }
+            repository.getPortfolioUserCount()
+                .onSuccess { response ->
+                    val count = response.data.userCount
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            dailyRequest = count
+                        )
+                    }
+                    Log.d("PortfolioInsightViewModel", "포트폴리오 분석 요청 횟수 조회 성공")
+                }
+                .onFailure { response ->
+                    val errorMessage = response.message ?: "포트폴리오 분석 요청 횟수 조회 실패"
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = errorMessage
+                        )
+                    }
+                    Log.d("PortfolioInsightViewModel", "포트폴리오 분석 요청 횟수 조회 실패")
                 }
         }
     }

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/PortfolioInsightScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/PortfolioInsightScreen.kt
@@ -1,18 +1,23 @@
 package com.moneymate.moneymate.ui.insight.screen
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -23,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -77,16 +83,41 @@ fun PortfolioInsightScreen(
                 .verticalScroll(state = scrollState),
             verticalArrangement = Arrangement.Center
         ) {
-
             when (uiState.value.isLoading) {
                 true -> {
                     Box(
                         modifier = Modifier.fillMaxSize()
                     ) {
-                        CircularProgressIndicator(
+                        Column(
                             modifier = Modifier.align(Alignment.Center),
-                            color = MoneyMateTheme.colors.deepBlue
-                        )
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center
+                        ) {
+                            Image(
+                                modifier = Modifier.size(80.dp),
+                                painter = painterResource(id = R.drawable.ic_moneymatelogo),
+                                contentDescription = "MoneyMate Logo",
+                            )
+                            Spacer(modifier = Modifier.height(48.dp))
+                            LinearProgressIndicator(
+                                color = MoneyMateTheme.colors.deepBlue,
+                                trackColor = MoneyMateTheme.colors.neutral300
+                            )
+                            Spacer(modifier = Modifier.height(24.dp))
+                            Text(
+                                text = "AI가 포트폴리오를 분석하고 있습니다",
+                                style = MoneyMateTheme.typography.body_01_M_16,
+                                color = MoneyMateTheme.colors.deepBlue,
+                                textAlign = TextAlign.Center
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = "잠시만 기다려주세요",
+                                style = MoneyMateTheme.typography.body_01_M_16,
+                                color = MoneyMateTheme.colors.deepBlue,
+                                textAlign = TextAlign.Center
+                            )
+                        }
                     }
                 }
                 false -> {

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/PortfolioInsightScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/PortfolioInsightScreen.kt
@@ -2,10 +2,13 @@ package com.moneymate.moneymate.ui.insight.screen
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,7 +16,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -76,83 +82,141 @@ fun PortfolioInsightScreen(
                 containerColor = MoneyMateTheme.colors.white
             )
         )
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 20.dp)
-                .verticalScroll(state = scrollState),
-            verticalArrangement = Arrangement.Center
-        ) {
-            when (uiState.value.isLoading) {
-                true -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize()
+        when (uiState.value.isLoading) {
+            true -> {
+                Box(
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        Image(
+                            modifier = Modifier.size(80.dp),
+                            painter = painterResource(id = R.drawable.ic_moneymatelogo),
+                            contentDescription = "MoneyMate Logo",
+                        )
+                        Spacer(modifier = Modifier.height(48.dp))
+                        LinearProgressIndicator(
+                            color = MoneyMateTheme.colors.deepBlue,
+                            trackColor = MoneyMateTheme.colors.neutral300
+                        )
+                        Spacer(modifier = Modifier.height(24.dp))
+                        Text(
+                            text = "AI가 포트폴리오를 분석하고 있습니다",
+                            style = MoneyMateTheme.typography.body_01_M_16,
+                            color = MoneyMateTheme.colors.deepBlue,
+                            textAlign = TextAlign.Center
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "잠시만 기다려주세요",
+                            style = MoneyMateTheme.typography.body_01_M_16,
+                            color = MoneyMateTheme.colors.deepBlue,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                }
+            }
+
+            false -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 20.dp)
+                        .verticalScroll(state = scrollState),
+                ) {
+                    Spacer(modifier = Modifier.size(10.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Column(
-                            modifier = Modifier.align(Alignment.Center),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.Center
+                            modifier = Modifier
                         ) {
-                            Image(
-                                modifier = Modifier.size(80.dp),
-                                painter = painterResource(id = R.drawable.ic_moneymatelogo),
-                                contentDescription = "MoneyMate Logo",
-                            )
-                            Spacer(modifier = Modifier.height(48.dp))
-                            LinearProgressIndicator(
-                                color = MoneyMateTheme.colors.deepBlue,
-                                trackColor = MoneyMateTheme.colors.neutral300
-                            )
-                            Spacer(modifier = Modifier.height(24.dp))
                             Text(
-                                text = "AI가 포트폴리오를 분석하고 있습니다",
-                                style = MoneyMateTheme.typography.body_01_M_16,
-                                color = MoneyMateTheme.colors.deepBlue,
-                                textAlign = TextAlign.Center
+                                text = "분석일자 : "+ uiState.value.insightDate.ifBlank { "정보 없음" },
+                                style = MoneyMateTheme.typography.body_01_M_14,
                             )
-                            Spacer(modifier = Modifier.height(8.dp))
                             Text(
-                                text = "잠시만 기다려주세요",
+                                text = "남은 횟수 3회", // TODO: 남은 횟수 동적 처리
+                                style = MoneyMateTheme.typography.body_01_M_14,
+                            )
+                        }
+                        Button(
+                            modifier = Modifier,
+                            contentPadding = PaddingValues(8.dp),
+                            shape = RoundedCornerShape(10.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MoneyMateTheme.colors.deepBlue,
+                                contentColor = MoneyMateTheme.colors.white,
+                                disabledContainerColor = MoneyMateTheme.colors.darkGray
+                            ),
+                            enabled = !uiState.value.isLoading,
+                            onClick = { viewModel.getPortfolioInsight() }
+                        ) {
+                            Text(
+                                text = "분석하기",
                                 style = MoneyMateTheme.typography.body_01_M_16,
-                                color = MoneyMateTheme.colors.deepBlue,
-                                textAlign = TextAlign.Center
+                                color = MoneyMateTheme.colors.white
                             )
                         }
                     }
-                }
-                false -> {
-                    CompositionLocalProvider(
-                        LocalTextStyle provides MoneyMateTheme.typography.insightArticleStyle
-                    ) {
-                        Material3RichText(
-                            style = RichTextStyle(
-                                headingStyle = { level, textStyle ->
-                                    when (level) {
-                                        0 -> textStyle.copy( // H1
-                                            fontSize = 24.sp,
-                                            lineHeight = 32.sp,
-                                            fontWeight = FontWeight.Bold
-                                        )
-                                        1 -> textStyle.copy( // H2
-                                            fontSize = 20.sp,
-                                            lineHeight = 28.sp,
-                                            fontWeight = FontWeight.Bold
-                                        )
-                                        2 -> textStyle.copy( // H3
-                                            fontSize = 18.sp,
-                                            lineHeight = 24.sp,
-                                            fontWeight = FontWeight.Bold
-                                        )
-                                        else -> textStyle.copy(
-                                            fontSize = 16.sp,
-                                            lineHeight = 20.sp,
-                                            fontWeight = FontWeight.Bold
-                                        )
-                                    }
-                                }
-                            )
+                    Spacer(modifier = Modifier.size(20.dp))
+
+                    // 내용이 없을 때는 중앙 정렬, 있을 때는 일반 표시
+                    if (uiState.value.insight.isBlank() && uiState.value.insightDate.isBlank()) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .weight(1f),
+                            contentAlignment = Alignment.Center
                         ) {
-                            Markdown(content = uiState.value.insight)
+                            Text(
+                                text = "아직 포트폴리오 분석을 하지 않았습니다.\n\n분석을 요청해주세요.",
+                                style = MoneyMateTheme.typography.body_01_M_16,
+                                textAlign = TextAlign.Center
+                            )
+                        }
+                    } else {
+                        CompositionLocalProvider(
+                            LocalTextStyle provides MoneyMateTheme.typography.insightArticleStyle
+                        ) {
+                            Material3RichText(
+                                style = RichTextStyle(
+                                    headingStyle = { level, textStyle ->
+                                        when (level) {
+                                            0 -> textStyle.copy( // H1
+                                                fontSize = 24.sp,
+                                                lineHeight = 32.sp,
+                                                fontWeight = FontWeight.Bold
+                                            )
+
+                                            1 -> textStyle.copy( // H2
+                                                fontSize = 20.sp,
+                                                lineHeight = 28.sp,
+                                                fontWeight = FontWeight.Bold
+                                            )
+
+                                            2 -> textStyle.copy( // H3
+                                                fontSize = 18.sp,
+                                                lineHeight = 24.sp,
+                                                fontWeight = FontWeight.Bold
+                                            )
+
+                                            else -> textStyle.copy(
+                                                fontSize = 16.sp,
+                                                lineHeight = 20.sp,
+                                                fontWeight = FontWeight.Bold
+                                            )
+                                        }
+                                    }
+                                )
+                            ) {
+                                Markdown(content = uiState.value.insight)
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/PortfolioInsightScreen.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/insight/screen/PortfolioInsightScreen.kt
@@ -141,7 +141,7 @@ fun PortfolioInsightScreen(
                                 style = MoneyMateTheme.typography.body_01_M_14,
                             )
                             Text(
-                                text = "남은 횟수 3회", // TODO: 남은 횟수 동적 처리
+                                text = "남은 횟수 ${3 - uiState.value.dailyRequest}회",
                                 style = MoneyMateTheme.typography.body_01_M_14,
                             )
                         }
@@ -152,9 +152,9 @@ fun PortfolioInsightScreen(
                             colors = ButtonDefaults.buttonColors(
                                 containerColor = MoneyMateTheme.colors.deepBlue,
                                 contentColor = MoneyMateTheme.colors.white,
-                                disabledContainerColor = MoneyMateTheme.colors.darkGray
+                                disabledContainerColor = MoneyMateTheme.colors.disabled
                             ),
-                            enabled = !uiState.value.isLoading,
+                            enabled = !uiState.value.isLoading && uiState.value.dailyRequest < 3,
                             onClick = { viewModel.getPortfolioInsight() }
                         ) {
                             Text(

--- a/app/src/main/java/com/moneymate/moneymate/ui/theme/Color.kt
+++ b/app/src/main/java/com/moneymate/moneymate/ui/theme/Color.kt
@@ -9,6 +9,7 @@ val Black = Color(0xFF000000)
 val BackgroundWhite = Color(0xFFF5F5F5)
 val DarkGray = Color(0xFF333333)
 val LightGray = Color(0x99333333)
+val Disabled = Color(0xFFC2C2C4)
 
 val Neutral100 = Color(0xFFF7F7F9)
 val Neutral300 = Color(0xFFE5E5E7)
@@ -26,6 +27,7 @@ data class MoneyMateColors(
     val backgroundWhite: Color,
     val darkGray: Color,
     val lightGray: Color,
+    val disabled: Color,
     val neutral100: Color,
     val neutral300: Color,
     val neutral500: Color,
@@ -40,6 +42,7 @@ val defaultMoneyMateColors = MoneyMateColors(
     backgroundWhite = BackgroundWhite,
     darkGray = DarkGray,
     lightGray = LightGray,
+    disabled = Disabled,
     neutral100 = Neutral100,
     neutral300 = Neutral300,
     neutral500 = Neutral500,

--- a/app/src/main/java/com/moneymate/moneymate/util/insight/InsightCacheManager.kt
+++ b/app/src/main/java/com/moneymate/moneymate/util/insight/InsightCacheManager.kt
@@ -1,0 +1,75 @@
+package com.moneymate.moneymate.util.insight
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.insightDataStore by preferencesDataStore(name = "insight_cache")
+
+@Singleton
+class InsightCacheManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private val PORTFOLIO_INSIGHT = stringPreferencesKey("portfolio_insight")
+        private val PORTFOLIO_INSIGHT_TIMESTAMP = stringPreferencesKey("portfolio_insight_timestamp")
+    }
+
+    /**
+     * 저장된 포트폴리오 인사이트를 가져옵니다.
+     */
+    fun getPortfolioInsight(): Flow<String?> {
+        return context.insightDataStore.data.map { preferences ->
+            preferences[PORTFOLIO_INSIGHT]
+        }
+    }
+
+    /**
+     * 포트폴리오 인사이트가 저장된 시간을 가져옵니다.
+     */
+    fun getPortfolioInsightTimestamp(): Flow<String?> {
+        return context.insightDataStore.data.map { preferences ->
+            preferences[PORTFOLIO_INSIGHT_TIMESTAMP]
+        }
+    }
+
+    /**
+     * 포트폴리오 인사이트를 저장합니다.
+     * @param insight 인사이트 내용
+     * @param timestamp 저장 시간 (기본값: 현재 시간)
+     */
+    suspend fun savePortfolioInsight(insight: String, timestamp: String) {
+        context.insightDataStore.edit { preferences ->
+            preferences[PORTFOLIO_INSIGHT] = insight
+            preferences[PORTFOLIO_INSIGHT_TIMESTAMP] = timestamp
+        }
+    }
+
+    /**
+     * 저장된 포트폴리오 인사이트를 삭제합니다.
+     */
+    suspend fun clearPortfolioInsight() {
+        context.insightDataStore.edit { preferences ->
+            preferences.remove(PORTFOLIO_INSIGHT)
+            preferences.remove(PORTFOLIO_INSIGHT_TIMESTAMP)
+        }
+    }
+
+    /**
+     * 타임스탬프를 포맷팅된 문자열로 반환합니다.
+     */
+    fun formatTimestamp(timestamp: LocalDateTime): String {
+        val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+        return timestamp.format(formatter)
+    }
+}
+


### PR DESCRIPTION
## 🚀 이슈번호


## ✏️ 변경사항
- 포트폴리오 분석 화면에서 매번 요청을 보내지 않고 캐싱한 정보를 우선적으로 불러오도록 처리
- 일일 포트폴리오 분석 요청 가능 횟수 정보를 불러온 후 ui에 반영(버튼 활성화 여부)
- 포트폴리오 요청시 로딩 애니메이션 추가
- 포트폴리오 분석 결과를 dataStore를 통해 캐싱

## 📷 스크린샷
<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/367c09a6-96fc-44f2-9113-e98ed6a7819b" />
<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/6938fed8-8c8d-4b1b-b1a9-c0adf482112b" />
<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/120d7d37-41ce-48d6-b48c-48de3bb2452d" />
<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/ab27bc52-146a-4533-a2b2-a6e0297191b5" />


## ✍️ 사용법


## 🎸 기타
